### PR TITLE
Add landing screen and unify loading experience

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -87,3 +87,15 @@ body > div[style*="position: fixed"][style*="bottom: 10px"][style*="right: 20px"
 [id*="nextjs"] {
     display: none !important;
 }
+
+@keyframes loading-bar {
+    0% {
+        transform: translateX(-100%);
+    }
+    50% {
+        transform: translateX(0%);
+    }
+    100% {
+        transform: translateX(100%);
+    }
+}

--- a/app/panel/access-levels/loading.tsx
+++ b/app/panel/access-levels/loading.tsx
@@ -1,3 +1,5 @@
+import LoadingScreen from "@/components/ui/loading-screen"
+
 export default function Loading() {
-  return null
+    return <LoadingScreen />
 }

--- a/app/panel/chat/loading.tsx
+++ b/app/panel/chat/loading.tsx
@@ -1,3 +1,5 @@
+import LoadingScreen from "@/components/ui/loading-screen"
+
 export default function Loading() {
-  return null
+    return <LoadingScreen />
 }

--- a/app/panel/loading.tsx
+++ b/app/panel/loading.tsx
@@ -1,3 +1,5 @@
+import LoadingScreen from "@/components/ui/loading-screen"
+
 export default function Loading() {
-  return null
+    return <LoadingScreen />
 }

--- a/components/ui/loading-screen.tsx
+++ b/components/ui/loading-screen.tsx
@@ -1,0 +1,28 @@
+import { cn } from "@/lib/utils"
+
+interface LoadingScreenProps {
+    text?: string
+    className?: string
+}
+
+export function LoadingScreen({ text = "LOADING..", className }: LoadingScreenProps) {
+    return (
+        <div className={cn("relative flex min-h-screen w-full items-center justify-center overflow-hidden", className)}>
+            <div className="absolute inset-0 bg-[url('/grad2.svg')] bg-cover bg-center transition-all duration-500 dark:bg-[url('/grad1.svg')]" />
+            <div className="absolute inset-0 bg-white/60 transition-colors duration-500 dark:bg-black/70" />
+            <div className="relative z-10 flex flex-col items-center gap-4 text-center">
+                <span className="text-xs font-medium uppercase tracking-[0.55em] text-black/60 dark:text-white/60">
+                    Sistema Aura
+                </span>
+                <span className="text-3xl font-semibold uppercase tracking-[0.6em] text-black/90 dark:text-white">
+                    {text}
+                </span>
+                <div className="mt-2 h-1 w-32 overflow-hidden rounded-full bg-black/10 dark:bg-white/10">
+                    <div className="h-full w-[200%] -translate-x-full animate-[loading-bar_1.6s_ease-in-out_infinite] bg-black/40 dark:bg-white/60" />
+                </div>
+            </div>
+        </div>
+    )
+}
+
+export default LoadingScreen

--- a/src/aura/App.tsx
+++ b/src/aura/App.tsx
@@ -1,12 +1,16 @@
 "use client"
 
+import { useState } from "react"
 import Home from "./features/view/Home"
+import Landing from "./features/view/Landing"
 import { ThemeProvider } from "./components/ThemeProvider"
 
 export default function App() {
-  return (
-    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-      <Home />
-    </ThemeProvider>
-  )
+    const [showHome, setShowHome] = useState(false)
+
+    return (
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+            {showHome ? <Home /> : <Landing onContinue={() => setShowHome(true)} />}
+        </ThemeProvider>
+    )
 }

--- a/src/aura/features/view/Landing.tsx
+++ b/src/aura/features/view/Landing.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import { ArrowRight } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+interface LandingProps {
+    onContinue: () => void
+}
+
+export default function Landing({ onContinue }: LandingProps) {
+    return (
+        <div className="relative min-h-screen w-full overflow-hidden">
+            <div
+                className="absolute inset-0 bg-cover bg-center"
+                style={{ backgroundImage: "url('/grad1.svg')" }}
+            />
+            <div className="absolute inset-0 bg-black/60" />
+
+            <a
+                href="https://github.com/"
+                target="_blank"
+                rel="noreferrer"
+                className="absolute left-6 top-6 z-20 text-xs font-semibold uppercase tracking-[0.6em] text-white/80 transition hover:text-white"
+            >
+                Chatbot com sistema integravo ♾
+            </a>
+
+            <div className="relative z-10 flex min-h-screen flex-col items-center justify-center px-4">
+                <div className="flex flex-col items-center justify-center gap-6 rounded-3xl border border-white/10 bg-white/5 p-12 text-center shadow-2xl backdrop-blur-md">
+                    <span className="text-[0.65rem] uppercase tracking-[0.65em] text-white/60">
+                        Produzido por autodidatas.
+                    </span>
+
+                    <Button
+                        size="lg"
+                        className="group flex items-center gap-3 rounded-full border border-white/20 bg-white/20 px-10 py-6 text-lg font-semibold uppercase tracking-[0.6em] text-white shadow-lg backdrop-blur-lg transition hover:scale-105 hover:border-white/40 hover:bg-white/30"
+                        onClick={onContinue}
+                    >
+                        Vamos lá!
+                        <ArrowRight className="h-5 w-5 transition-transform group-hover:translate-x-1" />
+                    </Button>
+
+                    <span className="text-xs uppercase tracking-[0.5em] text-white/50">
+                        Pronto para automatizar.
+                    </span>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/aura/features/view/Panel.tsx
+++ b/src/aura/features/view/Panel.tsx
@@ -9,6 +9,7 @@ import Header from "./homePanels/Header"
 import ColorPanel from "./homePanels/ColorPanel"
 import SearchPanel from "./homePanels/SearchPanel"
 import ChannelModal from "./homePanels/ChannelModal"
+import LoadingScreen from "@/components/ui/loading-screen"
 
 // Componente da barra lateral elegante para o painel
 const PanelElegantSidebar = ({ currentGradient }: { currentGradient: any }) => {
@@ -61,11 +62,7 @@ const PanelLayout = ({ children }: PanelProps) => {
     }, [])
 
     if (!mounted) {
-        return (
-            <div className="flex items-center justify-center h-screen bg-gray-900 text-white">
-                <div className="text-lg">Loading...</div>
-            </div>
-        )
+        return <LoadingScreen />
     }
 
     return (

--- a/src/aura/features/view/chat/ChatTemplate.tsx
+++ b/src/aura/features/view/chat/ChatTemplate.tsx
@@ -3,6 +3,7 @@
 import type React from "react"
 import { useState, useEffect } from "react"
 import { useTheme } from "next-themes"
+import LoadingScreen from "@/components/ui/loading-screen"
 import ChatSidebar from "./ChatSidebar"
 import ChatHeader from "./ChatHeader"
 import ChatMessages from "./ChatMessages"
@@ -1216,11 +1217,7 @@ O sistema funciona localmente sem ele.
     }
 
     if (!mounted || loading) {
-        return (
-            <div className="h-screen bg-black flex items-center justify-center">
-                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
-            </div>
-        )
+        return <LoadingScreen />
     }
 
     // Atualizar a contagem de conversas

--- a/src/aura/features/view/homePanels/ThemeContext.tsx
+++ b/src/aura/features/view/homePanels/ThemeContext.tsx
@@ -2,6 +2,7 @@
 
 import type React from "react"
 import { createContext, useContext, useState, useEffect, type ReactNode } from "react"
+import LoadingScreen from "@/components/ui/loading-screen"
 
 type HomeTheme = "dark" | "light"
 
@@ -367,11 +368,7 @@ export const HomeThemeProvider: React.FC<ThemeProviderProps> = ({ children }) =>
     }
 
     if (!isLoaded) {
-        return (
-            <div className="flex items-center justify-center h-screen bg-gray-900 text-white">
-                <div className="text-lg">Loading...</div>
-            </div>
-        )
+        return <LoadingScreen />
     }
 
     return <HomeThemeContext.Provider value={value}>{children}</HomeThemeContext.Provider>


### PR DESCRIPTION
## Summary
- add an entry landing experience that mirrors the provided hero, linking the CTA to the existing Home view and the banner text to GitHub
- introduce a reusable loading screen component with gradient background and typography matching the requested style
- apply the new loading presentation across panel routes, chat, and theme initialization while adding a subtle loading animation keyframe

## Testing
- not run (requires eslint configuration prompt)


------
https://chatgpt.com/codex/tasks/task_e_6907b120af40832680045384a09a2e5f