### PR TITLE
Improve gradient themes and flow workspace UI

### DIFF
--- a/public/grad3.svg
+++ b/public/grad3.svg
@@ -1,0 +1,21 @@
+<svg width="1600" height="1200" viewBox="0 0 1600 1200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="rainbow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 600) rotate(90) scale(700 900)">
+      <stop offset="0%" stop-color="#ffe29f"/>
+      <stop offset="15%" stop-color="#ffa99f"/>
+      <stop offset="35%" stop-color="#ff719a"/>
+      <stop offset="55%" stop-color="#a858e0"/>
+      <stop offset="75%" stop-color="#5a7efc"/>
+      <stop offset="100%" stop-color="#1fb6ff" stop-opacity="0.75"/>
+    </radialGradient>
+    <linearGradient id="shine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.6)"/>
+      <stop offset="40%" stop-color="rgba(255,255,255,0.1)"/>
+      <stop offset="100%" stop-color="rgba(255,255,255,0)"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="1200" fill="#05030d"/>
+  <rect width="1600" height="1200" fill="url(#rainbow)"/>
+  <ellipse cx="400" cy="200" rx="420" ry="320" fill="url(#shine)" transform="rotate(-12 400 200)"/>
+  <ellipse cx="1250" cy="950" rx="360" ry="260" fill="url(#shine)" transform="rotate(18 1250 950)" opacity="0.6"/>
+</svg>

--- a/public/grad4.svg
+++ b/public/grad4.svg
@@ -1,0 +1,18 @@
+<svg width="1600" height="1200" viewBox="0 0 1600 1200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="purpleGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 600) scale(850 700)">
+      <stop offset="0%" stop-color="#7c3aed"/>
+      <stop offset="35%" stop-color="#4c1d95"/>
+      <stop offset="100%" stop-color="#0b0416"/>
+    </radialGradient>
+    <radialGradient id="highlight" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(520 360) rotate(25) scale(520 420)">
+      <stop offset="0%" stop-color="#c084fc" stop-opacity="0.9"/>
+      <stop offset="100%" stop-color="#7c3aed" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="1600" height="1200" fill="#05010b"/>
+  <rect width="1600" height="1200" fill="url(#purpleGlow)"/>
+  <ellipse cx="520" cy="360" rx="520" ry="420" fill="url(#highlight)"/>
+  <ellipse cx="1180" cy="860" rx="380" ry="300" fill="url(#highlight)" transform="rotate(-20 1180 860)" opacity="0.4"/>
+  <circle cx="1320" cy="260" r="220" fill="#a855f7" fill-opacity="0.12"/>
+</svg>

--- a/src/aura/features/view/Flow.tsx
+++ b/src/aura/features/view/Flow.tsx
@@ -35,6 +35,8 @@ import {
     FiFolder,
     FiTrash2,
     FiCamera,
+    FiMousePointer,
+    FiSearch,
 } from "react-icons/fi"
 import { BotIcon } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -43,6 +45,25 @@ import { Avatar } from "@/components/ui/avatar"
 import { motion, AnimatePresence } from "framer-motion"
 import html2canvas from "html2canvas"
 import { toast } from "@/hooks/use-toast"
+
+const extractHexColor = (input?: string, fallback = "#6366f1") => {
+    if (!input) return fallback
+    const match = input.match(/#[0-9a-fA-F]{6}/)
+    return match ? match[0] : fallback
+}
+
+const hexToRgba = (hex: string, alpha = 1) => {
+    const sanitized = hex.replace("#", "")
+    if (sanitized.length !== 6) {
+        return `rgba(99, 102, 241, ${alpha})`
+    }
+
+    const r = Number.parseInt(sanitized.slice(0, 2), 16)
+    const g = Number.parseInt(sanitized.slice(2, 4), 16)
+    const b = Number.parseInt(sanitized.slice(4, 6), 16)
+
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`
+}
 
 // Componente da barra lateral elegante para o flow
 const FlowElegantSidebar = ({ currentGradient, theme }: { currentGradient: any; theme: string }) => {
@@ -94,7 +115,7 @@ const FlowElegantSidebar = ({ currentGradient, theme }: { currentGradient: any; 
 }
 
 // Componente do Indicador de Status com status de execução
-const FlowStatusIndicator = ({ startPosition, mousePosition, componentCount, theme }: any) => {
+const FlowStatusIndicator = ({ startPosition, mousePosition, componentCount, theme, currentGradient }: any) => {
     const isDark = theme === "dark"
     const [isExecuted, setIsExecuted] = useState(false)
 
@@ -103,7 +124,6 @@ const FlowStatusIndicator = ({ startPosition, mousePosition, componentCount, the
         setIsExecuted(executedFlow === "true")
     }, [])
 
-    // Escutar mudanças no localStorage
     useEffect(() => {
         const handleStorageChange = () => {
             const executedFlow = localStorage.getItem("executedFlow")
@@ -111,7 +131,6 @@ const FlowStatusIndicator = ({ startPosition, mousePosition, componentCount, the
         }
 
         window.addEventListener("storage", handleStorageChange)
-        // Também escutar mudanças internas
         const interval = setInterval(handleStorageChange, 1000)
 
         return () => {
@@ -120,96 +139,143 @@ const FlowStatusIndicator = ({ startPosition, mousePosition, componentCount, the
         }
     }, [])
 
+    const accentColor = extractHexColor(currentGradient?.primary, isDark ? "#6366f1" : "#4338ca")
+    const secondaryAccent = extractHexColor(currentGradient?.secondary, accentColor)
+
+    const containerStyle = {
+        background: isDark
+            ? "linear-gradient(140deg, rgba(13,16,24,0.9), rgba(17,23,36,0.82))"
+            : "linear-gradient(140deg, rgba(255,255,255,0.96), rgba(241,245,249,0.9))",
+        border: `1px solid ${hexToRgba(accentColor, isDark ? 0.4 : 0.25)}`,
+        boxShadow: `0 28px 60px ${hexToRgba(accentColor, 0.18)}`,
+        backdropFilter: "blur(18px)",
+        borderRadius: "24px",
+        padding: "18px 20px",
+    }
+
+    const statusCards = [
+        {
+            key: "status",
+            label: "Status do fluxo",
+            value: isExecuted ? "Executado" : "Não executado",
+            helper: isExecuted ? "Última execução sincronizada" : "Execute para habilitar o bot",
+            icon: isExecuted ? FiCheckCircle : FiXCircle,
+            iconColor: isExecuted ? "#22c55e" : "#f97316",
+            badge: isExecuted ? { text: "Pronto", color: "#22c55e" } : { text: "Pendente", color: "#f97316" },
+        },
+        {
+            key: "start",
+            label: "Início do fluxo",
+            value: `(${Math.round(startPosition.x)}, ${Math.round(startPosition.y)})`,
+            helper: "Coordenadas do nó INÍCIO",
+            icon: FiMapPin,
+            iconColor: secondaryAccent,
+        },
+        {
+            key: "cursor",
+            label: "Cursor em tempo real",
+            value: `(${Math.round(mousePosition.x)}, ${Math.round(mousePosition.y)})`,
+            helper: "Posição do mouse no canvas",
+            icon: FiMousePointer,
+            iconColor: "#a855f7",
+        },
+        {
+            key: "components",
+            label: "Componentes ativos",
+            value: componentCount.toString(),
+            helper: "Elementos configurados",
+            icon: FiLayers,
+            iconColor: "#f59e0b",
+            suffix: "itens",
+        },
+    ]
+
     return (
-        <div
-            className={`flex items-center gap-4 px-3 py-1.5 rounded-lg border text-xs transition-all duration-200 ${
-                isDark
-                    ? "bg-black hover:bg-gray-900 border border-gray-800 hover:border-gray-700 text-white"
-                    : "bg-gray-50 hover:bg-white border border-gray-200 hover:border-gray-300 text-gray-900"
-            }`}
-            style={{
-                boxShadow: isDark
-                    ? "0 0 0 1px rgba(255, 255, 255, 0.1), 0 0 10px rgba(255, 255, 255, 0.1)"
-                    : "0 0 0 1px rgba(0, 0, 0, 0.05), 0 0 8px rgba(0, 0, 0, 0.05)",
-                filter: isDark ? "drop-shadow(0 0 5px rgba(255, 255, 255, 0.1))" : "drop-shadow(0 0 3px rgba(0, 0, 0, 0.1))",
-            }}
-        >
-            {/* Status de Execução */}
-            <div className="flex items-center gap-1">
-                {isExecuted ? (
-                    <FiCheckCircle
-                        className="h-3 w-3 text-green-500"
-                        style={{
-                            filter: isDark
-                                ? "drop-shadow(0 0 4px rgba(34, 197, 94, 0.5))"
-                                : "drop-shadow(0 0 2px rgba(34, 197, 94, 0.3))",
-                        }}
-                    />
-                ) : (
-                    <FiXCircle
-                        className="h-3 w-3 text-red-500"
-                        style={{
-                            filter: isDark
-                                ? "drop-shadow(0 0 4px rgba(239, 68, 68, 0.5))"
-                                : "drop-shadow(0 0 2px rgba(239, 68, 68, 0.3))",
-                        }}
-                    />
-                )}
-                <span
-                    className={`font-semibold ${
-                        isDark
-                            ? "text-white drop-shadow-[0_0_4px_rgba(255,255,255,0.3)]"
-                            : "text-gray-900 drop-shadow-[0_0_2px_rgba(0,0,0,0.2)]"
-                    }`}
-                >
-          {isExecuted ? "EXECUTADO" : "NÃO EXECUTADO"}
-        </span>
-            </div>
-
-            {/* Separador */}
-            <div className={`w-px h-4 ${isDark ? "bg-gray-700" : "bg-gray-300"}`} />
-
-            {/* Posição do INÍCIO */}
-            <div className="flex items-center gap-1">
-                <FiMapPin
-                    className="h-3 w-3 text-blue-500"
+        <div className="w-full max-w-2xl">
+            <div className="relative overflow-hidden" style={containerStyle}>
+                <div
+                    className="pointer-events-none absolute inset-0 opacity-25"
                     style={{
-                        filter: isDark
-                            ? "drop-shadow(0 0 4px rgba(59, 130, 246, 0.5))"
-                            : "drop-shadow(0 0 2px rgba(59, 130, 246, 0.3))",
+                        background: `radial-gradient(circle at 0% 0%, ${hexToRgba(accentColor, 0.35)} 0%, transparent 55%), radial-gradient(circle at 100% 100%, ${hexToRgba(secondaryAccent, 0.3)} 0%, transparent 60%)`,
                     }}
                 />
-                <span
-                    className={`font-mono ${
-                        isDark
-                            ? "text-white drop-shadow-[0_0_4px_rgba(255,255,255,0.3)]"
-                            : "text-gray-900 drop-shadow-[0_0_2px_rgba(0,0,0,0.2)]"
-                    }`}
-                >
-          INÍCIO: ({Math.round(startPosition.x)}, {Math.round(startPosition.y)})
-        </span>
-            </div>
+                <div className="relative grid gap-3 sm:grid-cols-2">
+                    {statusCards.map((card) => {
+                        const Icon = card.icon
+                        const iconColor = card.iconColor
+                        const baseTextColor = isDark ? "#f8fafc" : "#0f172a"
 
-            {/* Separador */}
-            <div className={`w-px h-4 ${isDark ? "bg-gray-700" : "bg-gray-300"}`} />
-
-            {/* Posição do Mouse */}
-            <div className="flex items-center gap-1">
-                <span className="text-purple-500">Cursor</span>
-                <span className={`font-mono ${isDark ? "text-white" : "text-gray-900"}`}>
-          Mouse: ({Math.round(mousePosition.x)}, {Math.round(mousePosition.y)})
-        </span>
-            </div>
-
-            {/* Separador */}
-            <div className={`w-px h-4 ${isDark ? "bg-gray-700" : "bg-gray-300"}`} />
-
-            {/* Contador de Componentes */}
-            <div className="flex items-center gap-1">
-                <FiLayers className="h-3 w-3 text-orange-500" />
-                <span className={isDark ? "text-white" : "text-gray-900"}>
-          <span className="font-semibold">{componentCount}</span> componentes
-        </span>
+                        return (
+                            <div
+                                key={card.key}
+                                className="group relative overflow-hidden rounded-2xl border p-4 transition-transform duration-300 hover:-translate-y-0.5"
+                                style={{
+                                    background: isDark
+                                        ? "linear-gradient(150deg, rgba(17,24,39,0.72), rgba(15,23,42,0.58))"
+                                        : "linear-gradient(150deg, rgba(255,255,255,0.95), rgba(248,250,252,0.9))",
+                                    borderColor: hexToRgba(iconColor, isDark ? 0.32 : 0.22),
+                                    boxShadow: `0 18px 36px ${hexToRgba(iconColor, isDark ? 0.22 : 0.18)}`,
+                                }}
+                            >
+                                <div
+                                    className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+                                    style={{ background: hexToRgba(iconColor, isDark ? 0.12 : 0.08) }}
+                                />
+                                <div className="relative flex items-start justify-between gap-3">
+                                    <div className="flex items-center gap-3">
+                                        <div
+                                            className="flex h-10 w-10 items-center justify-center rounded-xl shadow-lg transition-transform duration-300 group-hover:scale-105"
+                                            style={{
+                                                background: hexToRgba(iconColor, isDark ? 0.2 : 0.14),
+                                                boxShadow: `0 12px 28px ${hexToRgba(iconColor, isDark ? 0.35 : 0.2)}`,
+                                            }}
+                                        >
+                                            <Icon className="h-5 w-5" style={{ color: iconColor }} />
+                                        </div>
+                                        <div className="flex flex-col gap-1">
+                                            <span
+                                                className="text-[11px] font-semibold uppercase tracking-[0.22em]"
+                                                style={{ color: hexToRgba(iconColor, isDark ? 0.7 : 0.55) }}
+                                            >
+                                                {card.label}
+                                            </span>
+                                            <span className="text-lg font-semibold" style={{ color: baseTextColor }}>
+                                                {card.value}
+                                                {card.suffix && (
+                                                    <span
+                                                        className="ml-1 text-sm font-medium"
+                                                        style={{ color: hexToRgba(iconColor, isDark ? 0.7 : 0.6) }}
+                                                    >
+                                                        {card.suffix}
+                                                    </span>
+                                                )}
+                                            </span>
+                                        </div>
+                                    </div>
+                                    {card.badge && (
+                                        <span
+                                            className="rounded-full px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.18em]"
+                                            style={{
+                                                background: hexToRgba(card.badge.color, isDark ? 0.22 : 0.14),
+                                                color: card.badge.color,
+                                            }}
+                                        >
+                                            {card.badge.text}
+                                        </span>
+                                    )}
+                                </div>
+                                {card.helper && (
+                                    <p
+                                        className="relative mt-3 text-xs leading-relaxed"
+                                        style={{ color: isDark ? "rgba(226,232,240,0.72)" : "rgba(30,41,59,0.65)" }}
+                                    >
+                                        {card.helper}
+                                    </p>
+                                )}
+                            </div>
+                        )
+                    })}
+                </div>
             </div>
         </div>
     )
@@ -665,6 +731,7 @@ const ImageMenu = ({ isOpen, onClose, onChangeBackground, onSaveImage, onResetBa
     const secondaryColor = currentGradient?.secondary || "#000000"
     const accentColor = currentGradient?.accent || "#000000"
     const glowColor = currentGradient?.glow || "#000000"
+    const accentHex = extractHexColor(currentGradient?.primary, isDark ? "#6366f1" : "#4338ca")
 
     return (
         <Dialog open={isOpen} onOpenChange={onClose}>
@@ -1303,38 +1370,78 @@ const FlowHeaderWithDialogs = ({
                     </div>
 
                     {/* Center Section: Search + Status */}
-                    <div className="flex-1 flex items-center justify-center gap-4 max-w-2xl">
-                        <form onSubmit={handleSearch} className="flex-1 max-w-md relative">
+                    <div className="flex-1 flex flex-col gap-4 px-3 max-w-5xl md:flex-row md:items-stretch md:justify-center">
+                        <form onSubmit={handleSearch} className="flex-1 max-w-xl">
                             <div
-                                className="relative rounded-full overflow-hidden transition-all"
+                                className="relative flex items-center gap-3 rounded-2xl px-4 py-2.5 transition-all duration-300"
                                 style={{
-                                    background: isDark ? "rgba(255, 255, 255, 0.05)" : "rgba(0, 0, 0, 0.03)",
-                                    border: `1px solid ${isSearchFocused ? glowColor : isDark ? "rgba(255, 255, 255, 0.1)" : "rgba(0, 0, 0, 0.08)"}`,
-                                    boxShadow: isSearchFocused ? `0 0 20px ${glowColor}30` : "none",
+                                    background: isDark
+                                        ? "linear-gradient(135deg, rgba(17,24,39,0.78), rgba(30,41,59,0.62))"
+                                        : "linear-gradient(135deg, rgba(255,255,255,0.96), rgba(241,245,249,0.9))",
+                                    border: `1px solid ${hexToRgba(accentHex, isSearchFocused ? (isDark ? 0.55 : 0.45) : (isDark ? 0.3 : 0.22))}`,
+                                    boxShadow: isSearchFocused
+                                        ? `0 22px 45px ${hexToRgba(accentHex, 0.28)}`
+                                        : `0 15px 32px ${hexToRgba(accentHex, 0.18)}`,
+                                    backdropFilter: "blur(18px)",
                                 }}
                             >
+                                <span
+                                    className="pointer-events-none absolute left-0 top-0 bottom-0 w-[2.5px] rounded-l-2xl"
+                                    style={{
+                                        background: `linear-gradient(180deg, transparent, ${hexToRgba(accentHex, 0.65)}, transparent)`
+                                    }}
+                                />
+                                <FiSearch
+                                    className="h-4 w-4 shrink-0"
+                                    style={{ color: isDark ? "#9ca3af" : "#6b7280" }}
+                                />
                                 <input
                                     type="text"
                                     value={searchValue}
                                     onChange={(e) => setSearchValue(e.target.value)}
                                     onFocus={() => setIsSearchFocused(true)}
                                     onBlur={() => setTimeout(() => setIsSearchFocused(false), 200)}
-                                    placeholder="Procurar ID do Componente"
-                                    className="w-full px-4 py-2 bg-transparent outline-none text-sm"
+                                    placeholder="Procurar ID ou rótulo do componente"
+                                    aria-label="Pesquisar componente pelo identificador"
+                                    className="w-full bg-transparent text-sm outline-none placeholder:text-slate-400"
+                                    style={{ color: isDark ? "#e2e8f0" : "#1f2937" }}
+                                />
+                                {searchValue && (
+                                    <button
+                                        type="button"
+                                        onClick={() => setSearchValue("")}
+                                        className="group rounded-full p-1 transition-colors"
+                                        style={{
+                                            background: isDark ? "rgba(255,255,255,0.08)" : "rgba(15,23,42,0.08)",
+                                        }}
+                                        aria-label="Limpar pesquisa"
+                                    >
+                                        <FiX
+                                            className="h-3.5 w-3.5"
+                                            style={{ color: isDark ? "#cbd5f5" : "#475569" }}
+                                        />
+                                    </button>
+                                )}
+                                <div
+                                    className="pointer-events-none absolute inset-0 rounded-2xl"
                                     style={{
-                                        color: isDark ? "#e5e7eb" : "#1f2937",
+                                        boxShadow: isSearchFocused
+                                            ? `0 0 0 1px ${hexToRgba(accentHex, 0.55)}`
+                                            : `0 0 0 1px ${hexToRgba(accentHex, 0.16)}`,
                                     }}
                                 />
                             </div>
                         </form>
 
-                        <FlowStatusIndicator
-                            startPosition={startPosition}
-                            mousePosition={mousePosition}
-                            componentCount={componentCount}
-                            theme={theme}
-                            currentGradient={currentGradient}
-                        />
+                        <div className="flex-1 min-w-[260px]">
+                            <FlowStatusIndicator
+                                startPosition={startPosition}
+                                mousePosition={mousePosition}
+                                componentCount={componentCount}
+                                theme={theme}
+                                currentGradient={currentGradient}
+                            />
+                        </div>
                     </div>
 
                     {/* Right Section: Utility Buttons + Save + Execute */}
@@ -1597,18 +1704,20 @@ const FlowLayout = () => {
                 workflowContainerRef={workflowContainerRef}
             />
 
-            <main className="flex-1 overflow-hidden" ref={workflowContainerRef}>
-                <WorkflowBuilder
-                    onActionsReady={handleActionsReady}
-                    onStartPositionChange={setStartPosition}
-                    onMousePositionChange={setMousePosition}
-                    onComponentCountChange={setComponentCount}
-                    onNodesChange={setFlowNodes}
-                    onEdgesChange={setFlowEdges}
-                    showSidebar={showSidebar}
-                    onToggleSidebar={toggleSidebar}
-                    onOpenBot={openBot}
-                />
+            <main className="relative flex-1 overflow-hidden pt-24" ref={workflowContainerRef}>
+                <div className="h-full">
+                    <WorkflowBuilder
+                        onActionsReady={handleActionsReady}
+                        onStartPositionChange={setStartPosition}
+                        onMousePositionChange={setMousePosition}
+                        onComponentCountChange={setComponentCount}
+                        onNodesChange={setFlowNodes}
+                        onEdgesChange={setFlowEdges}
+                        showSidebar={showSidebar}
+                        onToggleSidebar={toggleSidebar}
+                        onOpenBot={openBot}
+                    />
+                </div>
             </main>
 
             <AuraFlowBot isOpen={showBot} onClose={closeBot} />

--- a/src/aura/features/view/Home.tsx
+++ b/src/aura/features/view/Home.tsx
@@ -17,7 +17,6 @@ import AuraFlowBot from "./flow/aura-flow-bot"
 function HomeContent() {
     const isMobile = useMobile()
     const [scrollY, setScrollY] = useState(0)
-    const [mounted, setMounted] = useState(false)
     const { highContrast, reducedMotion } = useSettings()
     const [isCalendarOpen, setIsCalendarOpen] = useState(false)
     const [openFaqIndex, setOpenFaqIndex] = useState<number | null>(null)
@@ -27,8 +26,30 @@ function HomeContent() {
     const [currentGradient, setCurrentGradient] = useState("url('/grad1.svg')")
 
     useEffect(() => {
-        setMounted(true)
+        if (typeof window === "undefined") {
+            return
+        }
+
+        const savedGradient = window.localStorage.getItem("aura-home-gradient")
+        const gradientToApply = savedGradient || "url('/grad1.svg')"
+
+        setCurrentGradient(gradientToApply)
+        document.documentElement.style.setProperty("--aura-home-gradient", gradientToApply)
     }, [])
+
+    useEffect(() => {
+        if (typeof window === "undefined") {
+            return
+        }
+
+        try {
+            window.localStorage.setItem("aura-home-gradient", currentGradient)
+        } catch (error) {
+            console.warn("Não foi possível salvar o gradiente selecionado:", error)
+        }
+
+        document.documentElement.style.setProperty("--aura-home-gradient", currentGradient)
+    }, [currentGradient])
 
     useEffect(() => {
         const handleScroll = () => {
@@ -118,7 +139,9 @@ function HomeContent() {
                 />
                 <div
                     className="absolute inset-0 bg-cover bg-center bg-no-repeat transition-all duration-300"
-                    style={{ backgroundImage: currentGradient }}
+                    style={{
+                        backgroundImage: `var(--aura-home-gradient, ${currentGradient})`,
+                    }}
                 />
                 <div className="absolute inset-0 bg-black/60" />
             </div>

--- a/src/aura/features/view/Statistics.tsx
+++ b/src/aura/features/view/Statistics.tsx
@@ -26,6 +26,7 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001"
 
 export default function Statistics() {
     const { theme } = useTheme()
+    const isDark = theme === "dark"
 
     const [stats, setStats] = useState<StatsData>({ today: 0, week: 0, month: 0, total: 0 })
     const [conversations, setConversations] = useState<ConversationData[]>([])
@@ -443,7 +444,16 @@ export default function Statistics() {
                             ) : (
                                 <div className="space-y-4">
                                     {conversationHistory.map((message, index) => {
-                                        const isBot = message.sender === "bot" || message.sender === "operator"
+                                        const senderRaw = typeof message.sender === "string" ? message.sender : ""
+                                        const senderType = senderRaw.toLowerCase()
+                                        const isOperator = [
+                                            "operator",
+                                            "attendant",
+                                            "agent",
+                                            "human",
+                                            "atendente",
+                                        ].includes(senderType)
+                                        const isBot = ["bot", "assistant", "system", "fluxo", "flow"].includes(senderType)
                                         const timestamp = new Date(message.timestamp).toLocaleString("pt-BR", {
                                             year: "numeric",
                                             month: "2-digit",
@@ -453,19 +463,89 @@ export default function Statistics() {
                                         })
 
                                         return (
-                                            <div key={message.id || index} className={`flex ${isBot ? "justify-end" : "justify-start"}`}>
-                                                <div className={`max-w-[80%] ${isBot ? "items-end" : "items-start"} flex flex-col gap-1`}>
+                                            <div
+                                                key={message.id || index}
+                                                className={`flex ${isBot || isOperator ? "justify-end" : "justify-start"}`}
+                                            >
+                                                <div
+                                                    className={`max-w-[80%] ${
+                                                        isBot || isOperator ? "items-end" : "items-start"
+                                                    } flex flex-col gap-1`}
+                                                >
                                                     <div
-                                                        className={`rounded-2xl px-4 py-3 ${
-                                                            isBot
-                                                                ? "bg-blue-500 text-white"
-                                                                : theme === "dark"
-                                                                    ? "bg-[#1f1f1f] text-gray-100"
-                                                                    : "bg-gray-100 text-gray-900"
-                                                        }`}
+                                                        className="rounded-2xl px-4 py-3 border shadow-sm backdrop-blur-sm transition-transform"
+                                                        style={{
+                                                            background: isBot
+                                                                ? "linear-gradient(135deg, rgba(59,130,246,0.95), rgba(59,130,246,0.8))"
+                                                                : isOperator
+                                                                    ? isDark
+                                                                        ? "rgba(16,185,129,0.18)"
+                                                                        : "rgba(16,185,129,0.12)"
+                                                                    : isDark
+                                                                        ? "rgba(31,31,31,0.92)"
+                                                                        : "rgba(241,245,249,0.95)",
+                                                            color: isBot
+                                                                ? "#ffffff"
+                                                                : isOperator
+                                                                    ? isDark
+                                                                        ? "#d1fae5"
+                                                                        : "#065f46"
+                                                                    : isDark
+                                                                        ? "#f1f5f9"
+                                                                        : "#111827",
+                                                            borderColor: isBot
+                                                                ? "rgba(96,165,250,0.45)"
+                                                                : isOperator
+                                                                    ? isDark
+                                                                        ? "rgba(74,222,128,0.45)"
+                                                                        : "rgba(16,185,129,0.45)"
+                                                                    : isDark
+                                                                        ? "rgba(255,255,255,0.06)"
+                                                                        : "rgba(15,23,42,0.08)",
+                                                            boxShadow: isBot
+                                                                ? "0 18px 35px rgba(59,130,246,0.25)"
+                                                                : isOperator
+                                                                    ? "0 16px 32px rgba(16,185,129,0.22)"
+                                                                    : isDark
+                                                                        ? "0 12px 24px rgba(15,15,20,0.45)"
+                                                                        : "0 10px 20px rgba(15,23,42,0.1)",
+                                                        }}
                                                     >
-                                                        <p className="text-xs font-medium mb-1 opacity-80">{isBot ? "Bot" : "Cliente"}</p>
-                                                        <p className="text-sm whitespace-pre-wrap break-words">{message.text}</p>
+                                                        <p
+                                                            className="text-[11px] font-semibold uppercase tracking-[0.18em] mb-1 flex items-center gap-2"
+                                                            style={{
+                                                                color: isBot
+                                                                    ? "#cbd5f5"
+                                                                    : isOperator
+                                                                        ? isDark
+                                                                            ? "#34d399"
+                                                                            : "#047857"
+                                                                        : isDark
+                                                                            ? "#94a3b8"
+                                                                            : "#475569",
+                                                                letterSpacing: "0.2em",
+                                                            }}
+                                                        >
+                                                            {isBot
+                                                                ? "Fluxo automatizado"
+                                                                : isOperator
+                                                                    ? "Operador"
+                                                                    : "Cliente"}
+                                                            {isOperator && (
+                                                                <span
+                                                                    className="inline-flex h-2.5 w-2.5 rounded-full"
+                                                                    style={{
+                                                                        background: isDark ? "rgba(74,222,128,0.8)" : "rgba(16,185,129,0.8)",
+                                                                        boxShadow: isDark
+                                                                            ? "0 0 10px rgba(74,222,128,0.8)"
+                                                                            : "0 0 8px rgba(16,185,129,0.6)",
+                                                                    }}
+                                                                />
+                                                            )}
+                                                        </p>
+                                                        <p className="text-sm whitespace-pre-wrap break-words leading-relaxed">
+                                                            {message.text}
+                                                        </p>
                                                     </div>
                                                     <span className={`text-xs px-2 ${themedMutedText}`}>{timestamp}</span>
                                                 </div>

--- a/src/aura/features/view/homePanels/ThemeContext.tsx
+++ b/src/aura/features/view/homePanels/ThemeContext.tsx
@@ -51,6 +51,22 @@ const gradientThemes: GradientTheme[] = [
         accent: "linear-gradient(135deg, #06b6d4 0%, #3b82f6 50%, #8b5cf6 100%)",
         glow: "rgba(6, 182, 212, 0.6)",
     },
+    {
+        name: "Deep Purple",
+        primary: "linear-gradient(135deg, #4c1d95 0%, #6d28d9 50%, #4338ca 100%)",
+        secondary: "linear-gradient(135deg, #5b21b6 0%, #7c3aed 100%)",
+        accent: "linear-gradient(135deg, #a855f7 0%, #7c3aed 50%, #6366f1 100%)",
+        glow: "rgba(124, 58, 237, 0.65)",
+        headerBg: "#4c1d95",
+    },
+    {
+        name: "Rainbow Iridescent",
+        primary: "linear-gradient(135deg, #f97316 0%, #f43f5e 30%, #6366f1 70%, #22d3ee 100%)",
+        secondary: "linear-gradient(135deg, #fb7185 0%, #a855f7 50%, #38bdf8 100%)",
+        accent: "linear-gradient(135deg, #fde047 0%, #f472b6 35%, #8b5cf6 70%, #38bdf8 100%)",
+        glow: "rgba(99, 102, 241, 0.55)",
+        headerBg: "#4338ca",
+    },
 ]
 
 interface HomeThemeContextType {


### PR DESCRIPTION
## Summary
- add Deep Purple and Rainbow Iridescent gradient themes and persist the selected landing gradient
- improve conversation history labeling so operator replies stand out from automated flow messages
- refresh the flow workspace header, status indicator, and search layout while ensuring the canvas sits below the fixed header

## Testing
- `npm run lint` *(cannot run: command prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6908d075f0d88326bf9e3f0702d1c08b