### PR TITLE
Add sales management dashboard for the panel

### DIFF
--- a/app/panel/access-levels/page.tsx
+++ b/app/panel/access-levels/page.tsx
@@ -21,6 +21,7 @@ import {
   FileText,
   Table,
   Palette,
+  ShoppingBag,
 } from "lucide-react"
 import Link from "next/link"
 
@@ -69,12 +70,14 @@ export default function AccessLevelsPage() {
     FileText,
     Table,
     Palette,
+    ShoppingBag,
   }
 
   // Páginas disponíveis no sidebar organizadas por categoria
   const [availablePages] = useState([
     // MENU
     { id: "dashboard", name: "Dashboard", category: "MENU", icon: "BarChart3" },
+    { id: "sales", name: "Vendas", category: "MENU", icon: "ShoppingBag" },
 
     // TOOLS
     { id: "account", name: "Conta", category: "TOOLS", icon: "Users" },

--- a/app/panel/vendas/actions.ts
+++ b/app/panel/vendas/actions.ts
@@ -1,0 +1,147 @@
+"use server"
+
+import { randomUUID } from "node:crypto"
+import { revalidatePath } from "next/cache"
+
+import {
+    readWorkshopData,
+    writeWorkshopData,
+    type InventoryItem,
+    type WorkshopData,
+} from "@/src/server/workshop-data"
+
+function parseNumber(value: FormDataEntryValue | null, fallback = 0): number {
+    if (value === null) return fallback
+    const parsed = typeof value === "string" ? Number(value.replace(",", ".")) : Number(value)
+    return Number.isFinite(parsed) ? parsed : fallback
+}
+
+function sanitizeText(value: FormDataEntryValue | null): string {
+    if (!value) return ""
+    return String(value).trim()
+}
+
+export async function createInventoryItem(formData: FormData) {
+    const name = sanitizeText(formData.get("name"))
+    const category = sanitizeText(formData.get("category"))
+    const unitPrice = parseNumber(formData.get("unitPrice"))
+    const stockQuantity = parseNumber(formData.get("stockQuantity"))
+    const minimumStock = parseNumber(formData.get("minimumStock"))
+
+    if (!name) {
+        return { error: "Informe o nome da peça." }
+    }
+
+    if (!category) {
+        return { error: "Informe a categoria da peça." }
+    }
+
+    if (unitPrice <= 0) {
+        return { error: "O preço unitário deve ser maior que zero." }
+    }
+
+    if (stockQuantity < 0) {
+        return { error: "O estoque inicial não pode ser negativo." }
+    }
+
+    const data = await readWorkshopData()
+
+    const alreadyExists = data.inventory.some((item) => item.name.toLowerCase() === name.toLowerCase())
+    if (alreadyExists) {
+        return { error: "Já existe uma peça cadastrada com esse nome." }
+    }
+
+    const newItem: InventoryItem = {
+        id: `item-${randomUUID()}`,
+        name,
+        category,
+        unitPrice: Number(unitPrice.toFixed(2)),
+        stockQuantity: Math.floor(stockQuantity),
+        minimumStock: Math.max(0, Math.floor(minimumStock)),
+    }
+
+    const updatedData: WorkshopData = {
+        ...data,
+        inventory: [...data.inventory, newItem],
+    }
+
+    await writeWorkshopData(updatedData)
+    revalidatePath("/panel/vendas")
+
+    return {
+        success: true,
+        message: `Peça "${newItem.name}" cadastrada com sucesso.`,
+    }
+}
+
+export async function registerSale(formData: FormData) {
+    const itemId = sanitizeText(formData.get("itemId"))
+    const quantity = parseNumber(formData.get("quantity"))
+    const explicitUnitPrice = formData.get("salePrice")
+    const customer = sanitizeText(formData.get("customer"))
+    const notes = sanitizeText(formData.get("notes"))
+    const dateInput = sanitizeText(formData.get("date"))
+
+    if (!itemId) {
+        return { error: "Selecione a peça vendida." }
+    }
+
+    if (quantity <= 0) {
+        return { error: "A quantidade vendida deve ser maior que zero." }
+    }
+
+    const data = await readWorkshopData()
+    const inventoryItem = data.inventory.find((item) => item.id === itemId)
+
+    if (!inventoryItem) {
+        return { error: "Peça não encontrada no estoque." }
+    }
+
+    const unitPrice = explicitUnitPrice ? parseNumber(explicitUnitPrice, inventoryItem.unitPrice) : inventoryItem.unitPrice
+
+    if (unitPrice <= 0) {
+        return { error: "O preço de venda deve ser maior que zero." }
+    }
+
+    if (quantity > inventoryItem.stockQuantity) {
+        return {
+            error: `Estoque insuficiente. Disponível: ${inventoryItem.stockQuantity} unidade(s).`,
+        }
+    }
+
+    const normalizedDate = dateInput || new Date().toISOString().slice(0, 10)
+    const total = Number((unitPrice * quantity).toFixed(2))
+
+    const updatedInventory = data.inventory.map((item) =>
+        item.id === itemId
+            ? {
+                  ...item,
+                  stockQuantity: item.stockQuantity - Math.floor(quantity),
+              }
+            : item,
+    )
+
+    const saleId = `sale-${randomUUID()}`
+
+    const updatedSales = [
+        ...data.sales,
+        {
+            id: saleId,
+            itemId,
+            quantity: Math.floor(quantity),
+            unitPrice: Number(unitPrice.toFixed(2)),
+            total,
+            date: normalizedDate,
+            customer: customer || undefined,
+            notes: notes || undefined,
+        },
+    ]
+
+    await writeWorkshopData({ inventory: updatedInventory, sales: updatedSales })
+    revalidatePath("/panel/vendas")
+
+    return {
+        success: true,
+        message: `Venda registrada com sucesso (ID ${saleId}).`,
+    }
+}

--- a/app/panel/vendas/page.tsx
+++ b/app/panel/vendas/page.tsx
@@ -1,0 +1,15 @@
+import Panel from "@/src/aura/features/view/Panel"
+import SalesDashboard from "@/src/aura/features/sales/SalesDashboard"
+import { readWorkshopData } from "@/src/server/workshop-data"
+
+export const dynamic = "force-dynamic"
+
+export default async function VendasPage() {
+    const data = await readWorkshopData()
+
+    return (
+        <Panel>
+            <SalesDashboard initialData={data} />
+        </Panel>
+    )
+}

--- a/src/aura/features/sales/SalesDashboard.tsx
+++ b/src/aura/features/sales/SalesDashboard.tsx
@@ -1,0 +1,543 @@
+"use client"
+
+import { useEffect, useMemo, useRef, useState } from "react"
+import { useRouter } from "next/navigation"
+import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts"
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Textarea } from "@/components/ui/textarea"
+
+import { createInventoryItem, registerSale } from "@/app/panel/vendas/actions"
+import type { InventoryItem, SaleRecord, WorkshopData } from "@/src/server/workshop-data"
+
+interface SalesDashboardProps {
+    initialData: WorkshopData
+}
+
+interface AggregatedItem extends InventoryItem {
+    soldQuantity: number
+    revenue: number
+}
+
+const currencyFormatter = new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+})
+
+const numberFormatter = new Intl.NumberFormat("pt-BR")
+
+const dateFormatter = new Intl.DateTimeFormat("pt-BR", {
+    timeZone: "UTC",
+})
+
+export default function SalesDashboard({ initialData }: SalesDashboardProps) {
+    const router = useRouter()
+    const [data, setData] = useState<WorkshopData>(initialData)
+    const [successMessage, setSuccessMessage] = useState<string | null>(null)
+    const [errorMessage, setErrorMessage] = useState<string | null>(null)
+    const [inventorySubmitting, setInventorySubmitting] = useState(false)
+    const [saleSubmitting, setSaleSubmitting] = useState(false)
+    const [selectedItemId, setSelectedItemId] = useState<string>(initialData.inventory[0]?.id ?? "")
+
+    const inventoryFormRef = useRef<HTMLFormElement>(null)
+    const saleFormRef = useRef<HTMLFormElement>(null)
+
+    useEffect(() => {
+        setData(initialData)
+        if (!initialData.inventory.some((item) => item.id === selectedItemId)) {
+            setSelectedItemId(initialData.inventory[0]?.id ?? "")
+        }
+    }, [initialData, selectedItemId])
+
+    const selectedItem = useMemo(
+        () => data.inventory.find((item) => item.id === selectedItemId),
+        [data.inventory, selectedItemId],
+    )
+
+    const aggregatedInventory: AggregatedItem[] = useMemo(() => {
+        const salesByItem = data.sales.reduce<Record<string, { quantity: number; revenue: number }>>((acc, sale) => {
+            if (!acc[sale.itemId]) {
+                acc[sale.itemId] = { quantity: 0, revenue: 0 }
+            }
+            acc[sale.itemId].quantity += sale.quantity
+            acc[sale.itemId].revenue += sale.total
+            return acc
+        }, {})
+
+        return data.inventory.map((item) => ({
+            ...item,
+            soldQuantity: salesByItem[item.id]?.quantity ?? 0,
+            revenue: salesByItem[item.id]?.revenue ?? 0,
+        }))
+    }, [data.inventory, data.sales])
+
+    const totals = useMemo(() => {
+        const totalSalesCount = data.sales.length
+        const totalItemsSold = data.sales.reduce((sum, sale) => sum + sale.quantity, 0)
+        const totalRevenue = data.sales.reduce((sum, sale) => sum + sale.total, 0)
+        const totalStock = data.inventory.reduce((sum, item) => sum + item.stockQuantity, 0)
+        const stockValue = data.inventory.reduce((sum, item) => sum + item.stockQuantity * item.unitPrice, 0)
+        const lowStockItems = data.inventory.filter((item) => item.stockQuantity <= item.minimumStock).length
+
+        return {
+            totalSalesCount,
+            totalItemsSold,
+            totalRevenue,
+            totalStock,
+            stockValue,
+            lowStockItems,
+        }
+    }, [data.inventory, data.sales])
+
+    const topSellingItems = useMemo(
+        () =>
+            [...aggregatedInventory]
+                .sort((a, b) => b.revenue - a.revenue)
+                .slice(0, 5),
+        [aggregatedInventory],
+    )
+
+    const chartData = useMemo(
+        () => [
+            {
+                metric: "Total de vendas (itens)",
+                value: totals.totalItemsSold,
+                formula: "∑ quantidades vendidas",
+                formatter: (value: number) => numberFormatter.format(value),
+            },
+            {
+                metric: "Total em estoque (itens)",
+                value: totals.totalStock,
+                formula: "∑ quantidades em estoque",
+                formatter: (value: number) => numberFormatter.format(value),
+            },
+            {
+                metric: "Total ganho (R$)",
+                value: Number(totals.totalRevenue.toFixed(2)),
+                formula: "∑ (quantidade × preço de venda)",
+                formatter: (value: number) => currencyFormatter.format(value),
+            },
+        ],
+        [totals.totalItemsSold, totals.totalStock, totals.totalRevenue],
+    )
+
+    const handleCreateInventoryItem = async (formData: FormData) => {
+        setInventorySubmitting(true)
+        setSuccessMessage(null)
+        setErrorMessage(null)
+
+        const result = await createInventoryItem(formData)
+
+        if (result?.error) {
+            setErrorMessage(result.error)
+        } else {
+            setSuccessMessage(result?.message ?? "Peça cadastrada com sucesso.")
+            inventoryFormRef.current?.reset()
+        }
+
+        setInventorySubmitting(false)
+        router.refresh()
+    }
+
+    const handleRegisterSale = async (formData: FormData) => {
+        setSaleSubmitting(true)
+        setSuccessMessage(null)
+        setErrorMessage(null)
+
+        const result = await registerSale(formData)
+
+        if (result?.error) {
+            setErrorMessage(result.error)
+        } else {
+            setSuccessMessage(result?.message ?? "Venda registrada com sucesso.")
+            saleFormRef.current?.reset()
+            setSelectedItemId(data.inventory[0]?.id ?? "")
+        }
+
+        setSaleSubmitting(false)
+        router.refresh()
+    }
+
+    const handleSelectedItemChange = (value: string) => {
+        setSelectedItemId(value)
+        setErrorMessage(null)
+    }
+
+    const renderStatus = (item: AggregatedItem) => {
+        if (item.stockQuantity === 0) {
+            return <span className="text-destructive font-medium">Sem estoque</span>
+        }
+
+        if (item.stockQuantity <= item.minimumStock) {
+            return <span className="text-amber-500 font-medium">Atenção: estoque baixo</span>
+        }
+
+        return <span className="text-emerald-500 font-medium">Estoque saudável</span>
+    }
+
+    const getSaleDateLabel = (sale: SaleRecord) => {
+        if (!sale.date) return "-"
+        const parsed = new Date(`${sale.date}T00:00:00`)
+        if (Number.isNaN(parsed.getTime())) {
+            return sale.date
+        }
+        return dateFormatter.format(parsed)
+    }
+
+    const tooltipFormatter = (value: number, name: string, props: any) => {
+        const payload = props?.payload as { formatter?: (value: number) => string } | undefined
+        if (payload?.formatter) {
+            return payload.formatter(value)
+        }
+        return numberFormatter.format(value)
+    }
+
+    return (
+        <div className="space-y-6">
+            <div>
+                <h1 className="text-3xl font-bold tracking-tight text-foreground">Gestão de Vendas e Estoque</h1>
+                <p className="text-muted-foreground mt-1">
+                    Cadastre peças, registre vendas e acompanhe o desempenho financeiro da oficina em tempo real.
+                </p>
+            </div>
+
+            {(successMessage || errorMessage) && (
+                <div
+                    className={`rounded-lg border p-4 ${
+                        errorMessage ? "border-destructive/50 bg-destructive/10 text-destructive" : "border-emerald-500/40 bg-emerald-500/10 text-emerald-600"
+                    }`}
+                >
+                    <p className="font-medium">{errorMessage ? errorMessage : successMessage}</p>
+                </div>
+            )}
+
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Total de vendas</CardTitle>
+                        <CardDescription>Soma das quantidades vendidas (∑ quantidades).</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        <p className="text-3xl font-semibold">{numberFormatter.format(totals.totalItemsSold)}</p>
+                        <p className="text-muted-foreground text-sm mt-2">{totals.totalSalesCount} operações registradas.</p>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Total em estoque</CardTitle>
+                        <CardDescription>Soma das unidades disponíveis (∑ estoque atual).</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        <p className="text-3xl font-semibold">{numberFormatter.format(totals.totalStock)}</p>
+                        <p className="text-muted-foreground text-sm mt-2">
+                            Valor de reposição estimado: {currencyFormatter.format(totals.stockValue)}
+                        </p>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Total ganho</CardTitle>
+                        <CardDescription>Receita acumulada (∑ quantidade × preço de venda).</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        <p className="text-3xl font-semibold">{currencyFormatter.format(totals.totalRevenue)}</p>
+                        <p className="text-muted-foreground text-sm mt-2">
+                            Ticket médio: {currencyFormatter.format(totals.totalSalesCount ? totals.totalRevenue / totals.totalSalesCount : 0)}
+                        </p>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Alertas de estoque</CardTitle>
+                        <CardDescription>Itens com estoque igual ou abaixo do mínimo definido.</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        <p className="text-3xl font-semibold">{numberFormatter.format(totals.lowStockItems)}</p>
+                        <p className="text-muted-foreground text-sm mt-2">Monitore para evitar rupturas e atrasos.</p>
+                    </CardContent>
+                </Card>
+            </div>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>Resumo consolidado</CardTitle>
+                    <CardDescription>Comparativo direto entre vendas, estoque e receita.</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                    <div className="h-72 w-full">
+                        <ResponsiveContainer width="100%" height="100%">
+                            <BarChart data={chartData}>
+                                <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
+                                <XAxis dataKey="metric" tick={{ fontSize: 12 }} interval={0} />
+                                <YAxis tickFormatter={(value) => numberFormatter.format(value)} tick={{ fontSize: 12 }} />
+                                <Tooltip formatter={tooltipFormatter as any} labelFormatter={(label) => label} />
+                                <Bar dataKey="value" radius={[6, 6, 0, 0]} fill="hsl(var(--primary))" />
+                            </BarChart>
+                        </ResponsiveContainer>
+                    </div>
+                    <div className="grid gap-2 md:grid-cols-3">
+                        {chartData.map((entry) => (
+                            <div key={entry.metric} className="rounded-md border p-3 text-sm">
+                                <p className="font-semibold text-foreground">{entry.metric}</p>
+                                <p className="text-muted-foreground">{entry.formula}</p>
+                            </div>
+                        ))}
+                    </div>
+                </CardContent>
+            </Card>
+
+            <div className="grid gap-6 lg:grid-cols-3">
+                <Card className="lg:col-span-1">
+                    <CardHeader>
+                        <CardTitle>Cadastrar nova peça</CardTitle>
+                        <CardDescription>Inclua itens no estoque para disponibilizar no painel de vendas.</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        <form ref={inventoryFormRef} action={handleCreateInventoryItem} className="space-y-4">
+                            <div className="space-y-2">
+                                <Label htmlFor="name">Nome da peça</Label>
+                                <Input id="name" name="name" placeholder="Ex: Pastilha de freio traseira" required />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="category">Categoria</Label>
+                                <Input id="category" name="category" placeholder="Ex: Freios" required />
+                            </div>
+                            <div className="grid grid-cols-2 gap-4">
+                                <div className="space-y-2">
+                                    <Label htmlFor="unitPrice">Preço unitário (R$)</Label>
+                                    <Input
+                                        id="unitPrice"
+                                        name="unitPrice"
+                                        type="number"
+                                        inputMode="decimal"
+                                        min={0}
+                                        step="0.01"
+                                        placeholder="0,00"
+                                        required
+                                    />
+                                </div>
+                                <div className="space-y-2">
+                                    <Label htmlFor="stockQuantity">Estoque inicial</Label>
+                                    <Input
+                                        id="stockQuantity"
+                                        name="stockQuantity"
+                                        type="number"
+                                        min={0}
+                                        step={1}
+                                        placeholder="0"
+                                        required
+                                    />
+                                </div>
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="minimumStock">Estoque mínimo desejado</Label>
+                                <Input id="minimumStock" name="minimumStock" type="number" min={0} step={1} placeholder="0" />
+                            </div>
+                            <Button type="submit" className="w-full" disabled={inventorySubmitting}>
+                                {inventorySubmitting ? "Salvando..." : "Cadastrar peça"}
+                            </Button>
+                        </form>
+                    </CardContent>
+                </Card>
+
+                <Card className="lg:col-span-1">
+                    <CardHeader>
+                        <CardTitle>Registrar venda</CardTitle>
+                        <CardDescription>Atualize o estoque automaticamente ao registrar uma nova venda.</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        <form ref={saleFormRef} action={handleRegisterSale} className="space-y-4">
+                            <div className="space-y-2">
+                                <Label>Peça vendida</Label>
+                                <Select value={selectedItemId} onValueChange={handleSelectedItemChange}>
+                                    <SelectTrigger>
+                                        <SelectValue placeholder="Selecione uma peça" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {data.inventory.map((item) => (
+                                            <SelectItem key={item.id} value={item.id}>
+                                                {item.name} · {item.stockQuantity} un disponíveis
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                                <input type="hidden" name="itemId" value={selectedItemId} />
+                            </div>
+                            <div className="grid grid-cols-2 gap-4">
+                                <div className="space-y-2">
+                                    <Label htmlFor="quantity">Quantidade</Label>
+                                    <Input id="quantity" name="quantity" type="number" min={1} step={1} placeholder="0" required />
+                                    {selectedItem && (
+                                        <p className="text-xs text-muted-foreground">
+                                            Disponível em estoque: {numberFormatter.format(selectedItem.stockQuantity)} unidades.
+                                        </p>
+                                    )}
+                                </div>
+                                <div className="space-y-2">
+                                    <Label htmlFor="salePrice">Preço de venda (R$)</Label>
+                                    <Input
+                                        key={selectedItem?.id ?? "salePrice"}
+                                        id="salePrice"
+                                        name="salePrice"
+                                        type="number"
+                                        inputMode="decimal"
+                                        min={0}
+                                        step="0.01"
+                                        placeholder="0,00"
+                                        defaultValue={selectedItem?.unitPrice}
+                                        required
+                                    />
+                                </div>
+                            </div>
+                            <div className="grid grid-cols-2 gap-4">
+                                <div className="space-y-2">
+                                    <Label htmlFor="date">Data da venda</Label>
+                                    <Input id="date" name="date" type="date" max={new Date().toISOString().slice(0, 10)} />
+                                </div>
+                                <div className="space-y-2">
+                                    <Label htmlFor="customer">Cliente</Label>
+                                    <Input id="customer" name="customer" placeholder="Nome ou razão social" />
+                                </div>
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="notes">Observações</Label>
+                                <Textarea id="notes" name="notes" placeholder="Detalhes adicionais da venda" rows={3} />
+                            </div>
+                            <Button type="submit" className="w-full" disabled={saleSubmitting || !selectedItemId}>
+                                {saleSubmitting ? "Registrando..." : "Registrar venda"}
+                            </Button>
+                        </form>
+                    </CardContent>
+                </Card>
+
+                <Card className="lg:col-span-1">
+                    <CardHeader>
+                        <CardTitle>Top itens vendidos</CardTitle>
+                        <CardDescription>Ranking por faturamento acumulado (∑ venda.total).</CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                        {topSellingItems.length === 0 ? (
+                            <p className="text-muted-foreground text-sm">Nenhuma venda registrada até o momento.</p>
+                        ) : (
+                            <ul className="space-y-3 text-sm">
+                                {topSellingItems.map((item, index) => (
+                                    <li key={item.id} className="flex items-start justify-between gap-3">
+                                        <div>
+                                            <p className="font-medium text-foreground">
+                                                {index + 1}. {item.name}
+                                            </p>
+                                            <p className="text-muted-foreground">
+                                                {numberFormatter.format(item.soldQuantity)} un · {currencyFormatter.format(item.revenue)}
+                                            </p>
+                                        </div>
+                                        <span className="rounded-full bg-primary/10 px-2 py-1 text-xs font-semibold text-primary">
+                                            {item.category}
+                                        </span>
+                                    </li>
+                                ))}
+                            </ul>
+                        )}
+                    </CardContent>
+                </Card>
+            </div>
+
+            <div className="grid gap-6 lg:grid-cols-2">
+                <Card className="overflow-hidden">
+                    <CardHeader>
+                        <CardTitle>Controle de estoque</CardTitle>
+                        <CardDescription>Visão geral das peças cadastradas e seu status atual.</CardDescription>
+                    </CardHeader>
+                    <CardContent className="px-0">
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Peça</TableHead>
+                                    <TableHead>Categoria</TableHead>
+                                    <TableHead className="text-right">Estoque</TableHead>
+                                    <TableHead className="text-right">Min.</TableHead>
+                                    <TableHead className="text-right">Preço</TableHead>
+                                    <TableHead>Status</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {aggregatedInventory.map((item) => (
+                                    <TableRow key={item.id} className={item.stockQuantity <= item.minimumStock ? "bg-amber-500/5" : undefined}>
+                                        <TableCell>
+                                            <div className="font-medium text-foreground">{item.name}</div>
+                                            <p className="text-xs text-muted-foreground">
+                                                Vendidos: {numberFormatter.format(item.soldQuantity)} · Receita: {currencyFormatter.format(item.revenue)}
+                                            </p>
+                                        </TableCell>
+                                        <TableCell>{item.category}</TableCell>
+                                        <TableCell className="text-right">{numberFormatter.format(item.stockQuantity)}</TableCell>
+                                        <TableCell className="text-right">{numberFormatter.format(item.minimumStock)}</TableCell>
+                                        <TableCell className="text-right">{currencyFormatter.format(item.unitPrice)}</TableCell>
+                                        <TableCell>{renderStatus(item)}</TableCell>
+                                    </TableRow>
+                                ))}
+                                {aggregatedInventory.length === 0 && (
+                                    <TableRow>
+                                        <TableCell colSpan={6} className="text-center text-muted-foreground py-6">
+                                            Cadastre suas primeiras peças para começar o controle.
+                                        </TableCell>
+                                    </TableRow>
+                                )}
+                            </TableBody>
+                        </Table>
+                    </CardContent>
+                </Card>
+
+                <Card className="overflow-hidden">
+                    <CardHeader>
+                        <CardTitle>Histórico de vendas</CardTitle>
+                        <CardDescription>Detalhamento de cada venda registrada com ID e cliente.</CardDescription>
+                    </CardHeader>
+                    <CardContent className="px-0">
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>ID</TableHead>
+                                    <TableHead>Peça</TableHead>
+                                    <TableHead className="text-right">Qtde.</TableHead>
+                                    <TableHead className="text-right">Total</TableHead>
+                                    <TableHead>Cliente</TableHead>
+                                    <TableHead>Data</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {data.sales
+                                    .slice()
+                                    .sort((a, b) => (a.date > b.date ? -1 : 1))
+                                    .map((sale) => {
+                                        const item = data.inventory.find((inventoryItem) => inventoryItem.id === sale.itemId)
+                                        return (
+                                            <TableRow key={sale.id}>
+                                                <TableCell className="font-mono text-xs">{sale.id}</TableCell>
+                                                <TableCell>{item?.name ?? "Peça removida"}</TableCell>
+                                                <TableCell className="text-right">{numberFormatter.format(sale.quantity)}</TableCell>
+                                                <TableCell className="text-right">{currencyFormatter.format(sale.total)}</TableCell>
+                                                <TableCell>{sale.customer ?? "-"}</TableCell>
+                                                <TableCell>{getSaleDateLabel(sale)}</TableCell>
+                                            </TableRow>
+                                        )
+                                    })}
+                                {data.sales.length === 0 && (
+                                    <TableRow>
+                                        <TableCell colSpan={6} className="text-center text-muted-foreground py-6">
+                                            Nenhuma venda registrada até o momento.
+                                        </TableCell>
+                                    </TableRow>
+                                )}
+                            </TableBody>
+                        </Table>
+                    </CardContent>
+                </Card>
+            </div>
+        </div>
+    )
+}

--- a/src/aura/features/view/homePanels/Sidebar.tsx
+++ b/src/aura/features/view/homePanels/Sidebar.tsx
@@ -3,7 +3,7 @@
 import type React from "react"
 
 import { useState, useEffect } from "react"
-import { BarChart3, Users, Home, MessageSquare, Layers, ChevronRight, Palette } from "lucide-react"
+import { BarChart3, Users, Home, MessageSquare, Layers, ChevronRight, Palette, ShoppingBag } from "lucide-react"
 import Link from "next/link"
 import { useTheme } from "./ThemeContext"
 import { useChannelPermissions } from "../../../hooks/use-channel-permissions"
@@ -42,6 +42,13 @@ const Sidebar = () => {
             active: true,
             href: "/panel",
             pageId: "dashboard",
+        },
+        {
+            icon: ShoppingBag,
+            label: "Vendas",
+            hasSubmenu: false,
+            href: "/panel/vendas",
+            pageId: "sales",
         },
     ]
 

--- a/src/aura/hooks/use-channel-permissions.tsx
+++ b/src/aura/hooks/use-channel-permissions.tsx
@@ -17,6 +17,7 @@ export function useChannelPermissions() {
     const availablePages: PagePermission[] = [
         // MENU
         { id: "dashboard", name: "Dashboard", category: "MENU", icon: "Dashboard" },
+        { id: "sales", name: "Vendas", category: "MENU", icon: "ShoppingBag" },
 
         // TOOLS
         { id: "account", name: "Conta", category: "TOOLS", icon: "Usuários" },

--- a/src/data/workshopData.json
+++ b/src/data/workshopData.json
@@ -1,0 +1,149 @@
+{
+  "inventory": [
+    {
+      "id": "item-oleo-5w30",
+      "name": "Óleo de Motor Sintético 5W30",
+      "category": "Lubrificantes",
+      "unitPrice": 150.0,
+      "stockQuantity": 40,
+      "minimumStock": 10
+    },
+    {
+      "id": "item-filtro-oleo",
+      "name": "Filtro de Óleo",
+      "category": "Filtros",
+      "unitPrice": 45.0,
+      "stockQuantity": 60,
+      "minimumStock": 15
+    },
+    {
+      "id": "item-pastilha-freio",
+      "name": "Pastilha de Freio Dianteira",
+      "category": "Freios",
+      "unitPrice": 220.0,
+      "stockQuantity": 25,
+      "minimumStock": 8
+    },
+    {
+      "id": "item-lampada-h7",
+      "name": "Lâmpada Farol H7",
+      "category": "Elétrica",
+      "unitPrice": 35.0,
+      "stockQuantity": 80,
+      "minimumStock": 20
+    },
+    {
+      "id": "item-bateria-60ah",
+      "name": "Bateria 60 Ah",
+      "category": "Elétrica",
+      "unitPrice": 480.0,
+      "stockQuantity": 12,
+      "minimumStock": 4
+    },
+    {
+      "id": "item-liquido-arrefecimento",
+      "name": "Líquido de Arrefecimento",
+      "category": "Fluidos",
+      "unitPrice": 65.0,
+      "stockQuantity": 50,
+      "minimumStock": 12
+    },
+    {
+      "id": "item-correia-dentada",
+      "name": "Correia Dentada",
+      "category": "Motor",
+      "unitPrice": 180.0,
+      "stockQuantity": 18,
+      "minimumStock": 6
+    },
+    {
+      "id": "item-filtro-ar",
+      "name": "Filtro de Ar do Motor",
+      "category": "Filtros",
+      "unitPrice": 70.0,
+      "stockQuantity": 40,
+      "minimumStock": 10
+    },
+    {
+      "id": "item-velas-ignicao",
+      "name": "Velas de Ignição (jogo)",
+      "category": "Ignição",
+      "unitPrice": 120.0,
+      "stockQuantity": 30,
+      "minimumStock": 8
+    },
+    {
+      "id": "item-pneu-aro15",
+      "name": "Pneu Aro 15",
+      "category": "Pneus",
+      "unitPrice": 520.0,
+      "stockQuantity": 16,
+      "minimumStock": 5
+    }
+  ],
+  "sales": [
+    {
+      "id": "sale-20240105-01",
+      "itemId": "item-oleo-5w30",
+      "quantity": 3,
+      "unitPrice": 150.0,
+      "total": 450.0,
+      "date": "2024-01-05",
+      "customer": "Carlos Alberto"
+    },
+    {
+      "id": "sale-20240211-02",
+      "itemId": "item-filtro-oleo",
+      "quantity": 5,
+      "unitPrice": 45.0,
+      "total": 225.0,
+      "date": "2024-02-11",
+      "customer": "Oficina Irmãos Lima"
+    },
+    {
+      "id": "sale-20240322-03",
+      "itemId": "item-pastilha-freio",
+      "quantity": 2,
+      "unitPrice": 220.0,
+      "total": 440.0,
+      "date": "2024-03-22",
+      "customer": "Luciana Prado"
+    },
+    {
+      "id": "sale-20240410-04",
+      "itemId": "item-pneu-aro15",
+      "quantity": 1,
+      "unitPrice": 520.0,
+      "total": 520.0,
+      "date": "2024-04-10",
+      "customer": "Frota Express"
+    },
+    {
+      "id": "sale-20240518-05",
+      "itemId": "item-bateria-60ah",
+      "quantity": 1,
+      "unitPrice": 480.0,
+      "total": 480.0,
+      "date": "2024-05-18",
+      "customer": "Renato Siqueira"
+    },
+    {
+      "id": "sale-20240602-06",
+      "itemId": "item-liquido-arrefecimento",
+      "quantity": 4,
+      "unitPrice": 65.0,
+      "total": 260.0,
+      "date": "2024-06-02",
+      "customer": "Auto Center Bela Vista"
+    },
+    {
+      "id": "sale-20240714-07",
+      "itemId": "item-velas-ignicao",
+      "quantity": 2,
+      "unitPrice": 120.0,
+      "total": 240.0,
+      "date": "2024-07-14",
+      "customer": "Bruno Almeida"
+    }
+  ]
+}

--- a/src/server/workshop-data.ts
+++ b/src/server/workshop-data.ts
@@ -1,0 +1,49 @@
+import fs from "node:fs/promises"
+import path from "node:path"
+
+export interface InventoryItem {
+    id: string
+    name: string
+    category: string
+    unitPrice: number
+    stockQuantity: number
+    minimumStock: number
+}
+
+export interface SaleRecord {
+    id: string
+    itemId: string
+    quantity: number
+    unitPrice: number
+    total: number
+    date: string
+    customer?: string
+    notes?: string
+}
+
+export interface WorkshopData {
+    inventory: InventoryItem[]
+    sales: SaleRecord[]
+}
+
+const dataFilePath = path.join(process.cwd(), "src/data/workshopData.json")
+
+async function ensureDataFile(): Promise<void> {
+    try {
+        await fs.access(dataFilePath)
+    } catch (error) {
+        const defaultData: WorkshopData = { inventory: [], sales: [] }
+        await fs.mkdir(path.dirname(dataFilePath), { recursive: true })
+        await fs.writeFile(dataFilePath, JSON.stringify(defaultData, null, 2), "utf-8")
+    }
+}
+
+export async function readWorkshopData(): Promise<WorkshopData> {
+    await ensureDataFile()
+    const raw = await fs.readFile(dataFilePath, "utf-8")
+    return JSON.parse(raw) as WorkshopData
+}
+
+export async function writeWorkshopData(data: WorkshopData): Promise<void> {
+    await fs.writeFile(dataFilePath, JSON.stringify(data, null, 2), "utf-8")
+}


### PR DESCRIPTION
## Summary
- add a dedicated Vendas page to the panel with sales analytics, inventory tables, and forms to register pieces and sales
- persist inventory and sales records in a shared JSON store with server actions for creating items and recording sales
- seed the workshop data store and surface the new page in the sidebar and access control configuration

## Testing
- not run (npm run lint prompts for interactive configuration)


------
https://chatgpt.com/codex/tasks/task_e_690d1dad44548326b9dfef6fdb2efd64