### PR TITLE
Add sales node support to Python workflow bot

### DIFF
--- a/app/api/inventory/route.ts
+++ b/app/api/inventory/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server"
+
+import { readWorkshopData } from "@/src/server/workshop-data"
+
+export async function GET() {
+    const data = await readWorkshopData()
+
+    return NextResponse.json({
+        inventory: data.inventory ?? [],
+    })
+}

--- a/app/api/pedidos/route.ts
+++ b/app/api/pedidos/route.ts
@@ -1,0 +1,89 @@
+import { randomUUID } from "node:crypto"
+
+import { NextResponse } from "next/server"
+
+import {
+    readWorkshopData,
+    writeWorkshopData,
+    type SaleRequest,
+    type SaleRequestType,
+} from "@/src/server/workshop-data"
+
+function sanitizeText(value: unknown): string {
+    if (typeof value !== "string") return ""
+    return value.trim()
+}
+
+function normalizeType(value: unknown): SaleRequestType | null {
+    return value === "estoque" || value === "solicitacao" ? value : null
+}
+
+function parsePrice(value: unknown): number | undefined {
+    if (typeof value !== "number" && typeof value !== "string") return undefined
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? Number(parsed.toFixed(2)) : undefined
+}
+
+export async function GET() {
+    const data = await readWorkshopData()
+
+    return NextResponse.json({ saleRequests: data.saleRequests ?? [] })
+}
+
+export async function POST(request: Request) {
+    try {
+        const body = await request.json()
+        const type = normalizeType(body?.type)
+        const itemName = sanitizeText(body?.itemName)
+        const requestedName = sanitizeText(body?.requestedName)
+        const notes = sanitizeText(body?.notes)
+        const price = parsePrice(body?.price)
+        const source = body?.source === "painel" ? "painel" : "workflow"
+
+        if (!type) {
+            return NextResponse.json({ error: "Tipo de pedido inválido." }, { status: 400 })
+        }
+
+        if (!itemName && !requestedName) {
+            return NextResponse.json({ error: "Informe o item desejado." }, { status: 400 })
+        }
+
+        const data = await readWorkshopData()
+        const now = new Date()
+
+        const newRequest: SaleRequest = {
+            id: `pedido-${randomUUID()}`,
+            type,
+            itemId: sanitizeText(body?.itemId) || undefined,
+            itemName: itemName || requestedName,
+            requestedName: requestedName || undefined,
+            price,
+            status: "pendente",
+            createdAt: now.toISOString(),
+            source,
+            notes: notes || undefined,
+        }
+
+        if (type === "estoque") {
+            const pickupDeadline = new Date(now)
+            pickupDeadline.setDate(pickupDeadline.getDate() + 3)
+            newRequest.pickupDeadline = pickupDeadline.toISOString()
+        } else {
+            const contactBy = new Date(now)
+            contactBy.setDate(contactBy.getDate() + 7)
+            newRequest.contactBy = contactBy.toISOString()
+        }
+
+        const updatedData = {
+            ...data,
+            saleRequests: [...(data.saleRequests ?? []), newRequest],
+        }
+
+        await writeWorkshopData(updatedData)
+
+        return NextResponse.json({ saleRequest: newRequest }, { status: 201 })
+    } catch (error) {
+        console.error("Erro ao registrar pedido:", error)
+        return NextResponse.json({ error: "Não foi possível registrar o pedido." }, { status: 500 })
+    }
+}

--- a/app/panel/pedidos/page.tsx
+++ b/app/panel/pedidos/page.tsx
@@ -1,0 +1,15 @@
+import Panel from "@/src/aura/features/view/Panel"
+import OrdersDashboard from "@/src/aura/features/sales/OrdersDashboard"
+import { readWorkshopData } from "@/src/server/workshop-data"
+
+export const dynamic = "force-dynamic"
+
+export default async function PedidosPage() {
+    const data = await readWorkshopData()
+
+    return (
+        <Panel>
+            <OrdersDashboard saleRequests={data.saleRequests ?? []} />
+        </Panel>
+    )
+}

--- a/src/aura/features/sales/OrdersDashboard.tsx
+++ b/src/aura/features/sales/OrdersDashboard.tsx
@@ -1,0 +1,176 @@
+"use client"
+
+import { useMemo } from "react"
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Separator } from "@/components/ui/separator"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { type SaleRequest } from "@/src/server/workshop-data"
+
+interface OrdersDashboardProps {
+    saleRequests: SaleRequest[]
+}
+
+const currencyFormatter = new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+})
+
+const dateFormatter = new Intl.DateTimeFormat("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+})
+
+const statusLabels: Record<SaleRequest["status"], string> = {
+    pendente: "Pendente",
+    confirmada: "Confirmada",
+    cancelada: "Cancelada",
+}
+
+const statusClasses: Record<SaleRequest["status"], string> = {
+    pendente: "bg-amber-100 text-amber-700 border border-amber-200",
+    confirmada: "bg-emerald-100 text-emerald-700 border border-emerald-200",
+    cancelada: "bg-rose-100 text-rose-700 border border-rose-200",
+}
+
+const typeLabels: Record<SaleRequest["type"], string> = {
+    estoque: "Item em estoque",
+    solicitacao: "Solicitação especial",
+}
+
+export default function OrdersDashboard({ saleRequests }: OrdersDashboardProps) {
+    const totals = useMemo(() => {
+        const total = saleRequests.length
+        const pending = saleRequests.filter((request) => request.status === "pendente").length
+        const confirmed = saleRequests.filter((request) => request.status === "confirmada").length
+        const cancelled = saleRequests.filter((request) => request.status === "cancelada").length
+
+        return { total, pending, confirmed, cancelled }
+    }, [saleRequests])
+
+    return (
+        <div className="space-y-6">
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                <Card>
+                    <CardHeader className="pb-2">
+                        <CardDescription>Pedidos totais</CardDescription>
+                        <CardTitle className="text-3xl font-bold">{totals.total}</CardTitle>
+                    </CardHeader>
+                    <CardContent className="text-sm text-muted-foreground">
+                        Entradas registradas pelo fluxo e painel.
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader className="pb-2">
+                        <CardDescription>Pedidos pendentes</CardDescription>
+                        <CardTitle className="text-3xl font-bold">{totals.pending}</CardTitle>
+                    </CardHeader>
+                    <CardContent className="text-sm text-muted-foreground">
+                        Aguardando retirada ou confirmação.
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader className="pb-2">
+                        <CardDescription>Confirmados</CardDescription>
+                        <CardTitle className="text-3xl font-bold">{totals.confirmed}</CardTitle>
+                    </CardHeader>
+                    <CardContent className="text-sm text-muted-foreground">
+                        Pedidos já validados.
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader className="pb-2">
+                        <CardDescription>Cancelados</CardDescription>
+                        <CardTitle className="text-3xl font-bold">{totals.cancelled}</CardTitle>
+                    </CardHeader>
+                    <CardContent className="text-sm text-muted-foreground">
+                        Inclui itens expirados ou recusados.
+                    </CardContent>
+                </Card>
+            </div>
+
+            <Card>
+                <CardHeader className="pb-3">
+                    <CardTitle>Pedidos registrados</CardTitle>
+                    <CardDescription>Pedidos vindos do node de vendas e solicitações especiais.</CardDescription>
+                </CardHeader>
+                <Separator />
+                <CardContent className="pt-4">
+                    {saleRequests.length === 0 ? (
+                        <Alert>
+                            <AlertTitle>Nenhum pedido encontrado</AlertTitle>
+                            <AlertDescription>
+                                Quando os clientes confirmarem compras ou solicitarem itens, eles aparecerão aqui.
+                            </AlertDescription>
+                        </Alert>
+                    ) : (
+                        <ScrollArea className="max-h-[520px] pr-4">
+                            <Table>
+                                <TableHeader>
+                                    <TableRow>
+                                        <TableHead>Pedido</TableHead>
+                                        <TableHead>Tipo</TableHead>
+                                        <TableHead>Status</TableHead>
+                                        <TableHead>Valor</TableHead>
+                                        <TableHead>Prazo</TableHead>
+                                        <TableHead>Origem</TableHead>
+                                    </TableRow>
+                                </TableHeader>
+                                <TableBody>
+                                    {saleRequests.map((request) => {
+                                        const value =
+                                            typeof request.price === "number"
+                                                ? currencyFormatter.format(request.price)
+                                                : "—"
+                                        const deadline = request.pickupDeadline || request.contactBy
+                                        const deadlineLabel = deadline
+                                            ? dateFormatter.format(new Date(deadline))
+                                            : "—"
+
+                                        return (
+                                            <TableRow key={request.id}>
+                                                <TableCell>
+                                                    <div className="space-y-1">
+                                                        <p className="font-medium leading-tight">{request.itemName}</p>
+                                                        {request.requestedName && (
+                                                            <p className="text-xs text-muted-foreground">
+                                                                Solicitado: {request.requestedName}
+                                                            </p>
+                                                        )}
+                                                        <p className="text-xs text-muted-foreground">
+                                                            {dateFormatter.format(new Date(request.createdAt))}
+                                                        </p>
+                                                    </div>
+                                                </TableCell>
+                                                <TableCell>
+                                                    <Badge variant="outline" className="text-xs">
+                                                        {typeLabels[request.type]}
+                                                    </Badge>
+                                                </TableCell>
+                                                <TableCell>
+                                                    <Badge variant="outline" className={`${statusClasses[request.status]} text-xs`}>
+                                                        {statusLabels[request.status]}
+                                                    </Badge>
+                                                </TableCell>
+                                                <TableCell>{value}</TableCell>
+                                                <TableCell>{deadlineLabel}</TableCell>
+                                                <TableCell className="capitalize">{request.source ?? "workflow"}</TableCell>
+                                            </TableRow>
+                                        )
+                                    })}
+                                </TableBody>
+                            </Table>
+                        </ScrollArea>
+                    )}
+                </CardContent>
+            </Card>
+        </div>
+    )
+}

--- a/src/aura/features/view/flow/node-library.tsx
+++ b/src/aura/features/view/flow/node-library.tsx
@@ -14,6 +14,7 @@ import {
     ExternalLink,
     Calendar,
     Users,
+    ShoppingCart,
 } from "lucide-react"
 import { useTheme } from "../homePanels/ThemeContext"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog"
@@ -43,6 +44,12 @@ const nodeTypes = [
         label: "Agentes",
         icon: Users,
         description: "Transfere para operador humano",
+    },
+    {
+        type: "venda",
+        label: "Venda",
+        icon: ShoppingCart,
+        description: "Lista itens cadastrados e registra pedidos",
     },
     {
         type: "process",

--- a/src/aura/features/view/flow/nodes/venda-node.tsx
+++ b/src/aura/features/view/flow/nodes/venda-node.tsx
@@ -1,0 +1,129 @@
+"use client"
+
+import type React from "react"
+
+import { memo, useEffect, useState } from "react"
+import { Handle, Position, type NodeProps } from "reactflow"
+import { ShoppingCart, Sparkles, X } from "lucide-react"
+
+import { useTheme } from "../../homePanels/ThemeContext"
+
+interface VendaNodeProps extends NodeProps {
+    onRemove?: () => void
+    onUpdateData?: (data: any) => void
+}
+
+export const VendaNode = memo(({ data, isConnectable, onRemove, onUpdateData }: VendaNodeProps) => {
+    const [message, setMessage] = useState(
+        data.message ||
+            "Aqui estão os itens disponíveis para venda. Digite o número do item desejado ou 0 para solicitar algo que não esteja na lista.",
+    )
+    const { theme, currentGradient } = useTheme()
+    const isDark = theme === "dark"
+
+    useEffect(() => {
+        if (data.message) {
+            setMessage(data.message)
+        }
+    }, [data.message])
+
+    const handleRemove = (e: React.MouseEvent) => {
+        e.stopPropagation()
+        if (onRemove) onRemove()
+    }
+
+    const updateMessage = (newMessage: string) => {
+        setMessage(newMessage)
+        if (onUpdateData) onUpdateData({ message: newMessage })
+    }
+
+    const getPrimaryColor = () => {
+        const match = currentGradient.primary.match(/#[0-9a-fA-F]{6}/)
+        return match ? match[0] : isDark ? "#10b981" : "#3b82f6"
+    }
+
+    const primaryColor = getPrimaryColor()
+
+    return (
+        <div
+            className="px-4 py-3 shadow-lg rounded-xl min-w-[300px] max-w-[340px] relative group backdrop-blur-sm"
+            style={{
+                background: isDark
+                    ? `linear-gradient(135deg, rgba(0,0,0,0.9) 0%, ${primaryColor}15 100%)`
+                    : `linear-gradient(135deg, rgba(255,255,255,0.95) 0%, ${primaryColor}10 100%)`,
+                border: isDark ? `2px solid ${primaryColor}50` : `2px solid ${primaryColor}40`,
+                boxShadow: isDark ? `0 4px 15px ${primaryColor}30` : `0 4px 15px ${primaryColor}20`,
+            }}
+        >
+            <button
+                onClick={handleRemove}
+                className="absolute -top-2 -right-2 w-6 h-6 bg-gradient-to-br from-red-500 to-red-600 text-white rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-all shadow-lg hover:scale-110 z-10"
+            >
+                <X className="h-3 w-3" />
+            </button>
+
+            <div className="flex items-center justify-between mb-3">
+                <div className="flex items-center">
+                    <div
+                        className="rounded-full w-8 h-8 flex items-center justify-center border"
+                        style={{
+                            background: isDark ? `${primaryColor}20` : `${primaryColor}15`,
+                            borderColor: isDark ? `${primaryColor}40` : `${primaryColor}30`,
+                        }}
+                    >
+                        <ShoppingCart className="h-4 w-4" style={{ color: primaryColor }} />
+                    </div>
+                    <div className="ml-2">
+                        <div
+                            className="text-sm font-semibold flex items-center gap-1.5"
+                            style={{ color: isDark ? "#f4f4f5" : "#18181b" }}
+                        >
+                            <Sparkles className="h-3.5 w-3.5" style={{ color: primaryColor }} />
+                            Vendas - ID: {data.customId || "#1"}
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div className="text-xs mb-2 font-semibold" style={{ color: primaryColor }}>
+                Lista os itens do painel de vendas
+            </div>
+            <div className="text-xs mb-2 leading-relaxed" style={{ color: isDark ? "#a1a1aa" : "#71717a" }}>
+                O bot apresentará os itens cadastrados em /panel/vendas com preço e ordem de cadastro. Caso o cliente não
+                encontre o item, poderá registrar uma solicitação.
+            </div>
+
+            <div className="relative mb-3">
+                <textarea
+                    value={message}
+                    onChange={(e) => updateMessage(e.target.value)}
+                    className="w-full rounded-lg p-2 min-h-[100px] text-xs resize-none focus:outline-none focus:ring-2"
+                    style={{
+                        background: isDark ? "rgba(0,0,0,0.5)" : "rgba(255,255,255,0.9)",
+                        border: isDark ? "1px solid rgba(255,255,255,0.1)" : "1px solid rgba(0,0,0,0.1)",
+                        color: isDark ? "#f4f4f5" : "#18181b",
+                    }}
+                    placeholder="Mensagem introdutória"
+                />
+            </div>
+
+            <Handle
+                type="target"
+                position={Position.Top}
+                isConnectable={isConnectable}
+                className="w-3 h-3 border-2 shadow-lg"
+                style={{ background: "#eab308", borderColor: isDark ? "#000" : "#fff" }}
+            />
+
+            <Handle
+                type="source"
+                position={Position.Bottom}
+                isConnectable={isConnectable}
+                className="w-3 h-3 border-2 shadow-lg"
+                style={{ background: "#22c55e", borderColor: isDark ? "#000" : "#fff" }}
+            />
+        </div>
+    )
+})
+
+VendaNode.displayName = "VendaNode"

--- a/src/aura/features/view/flow/workflow-builder.tsx
+++ b/src/aura/features/view/flow/workflow-builder.tsx
@@ -32,6 +32,7 @@ import { StartNode } from "./nodes/start-node"
 import { FinalizarNode } from "./nodes/finalizar-node"
 import { AgendamentoNode } from "./nodes/agendamento-node" // Import AgendamentoNode
 import { AgentesNode } from "./nodes/agentes-node" // Import AgentesNode
+import { VendaNode } from "./nodes/venda-node"
 import { generateNodeId, createNode } from "@/lib/workflow-utils"
 import type { WorkflowNode } from "@/lib/types"
 import { useTheme } from "../homePanels/ThemeContext"
@@ -63,6 +64,13 @@ const nodeTypes: NodeTypes = {
     ),
     agentes: (props) => (
         <AgentesNode
+            {...props}
+            onRemove={() => removeNodeById(props.id)}
+            onUpdateData={(data) => updateNodeDataById(props.id, data)}
+        />
+    ),
+    venda: (props) => (
+        <VendaNode
             {...props}
             onRemove={() => removeNodeById(props.id)}
             onUpdateData={(data) => updateNodeDataById(props.id, data)}

--- a/src/aura/features/view/homePanels/Sidebar.tsx
+++ b/src/aura/features/view/homePanels/Sidebar.tsx
@@ -3,7 +3,7 @@
 import type React from "react"
 
 import { useState, useEffect } from "react"
-import { BarChart3, Users, Home, MessageSquare, Layers, ChevronRight, Palette, Wrench } from "lucide-react"
+import { BarChart3, Users, Home, MessageSquare, Layers, ChevronRight, Palette, Wrench, ShoppingBag } from "lucide-react"
 import Link from "next/link"
 import { useTheme } from "./ThemeContext"
 import { useChannelPermissions } from "../../../hooks/use-channel-permissions"
@@ -48,6 +48,13 @@ const Sidebar = () => {
             label: "Oficina",
             hasSubmenu: false,
             href: "/panel/vendas",
+            pageId: "sales",
+        },
+        {
+            icon: ShoppingBag,
+            label: "Pedidos",
+            hasSubmenu: false,
+            href: "/panel/pedidos",
             pageId: "sales",
         },
     ]

--- a/src/server/workshop-data.ts
+++ b/src/server/workshop-data.ts
@@ -21,6 +21,25 @@ export interface SaleRecord {
     notes?: string
 }
 
+export type SaleRequestType = "estoque" | "solicitacao"
+
+export type SaleRequestStatus = "pendente" | "confirmada" | "cancelada"
+
+export interface SaleRequest {
+    id: string
+    type: SaleRequestType
+    itemId?: string
+    itemName: string
+    requestedName?: string
+    price?: number
+    status: SaleRequestStatus
+    createdAt: string
+    pickupDeadline?: string
+    contactBy?: string
+    source?: "workflow" | "painel"
+    notes?: string
+}
+
 export type ServiceOrderStatus = "aberta" | "em_andamento" | "aguardando_peca" | "concluida" | "cancelada"
 
 export type ServicePriority = "baixa" | "media" | "alta"
@@ -80,6 +99,7 @@ export interface WorkshopData {
     serviceOrders: ServiceOrder[]
     maintenanceTasks: MaintenanceTask[]
     financialRecords: FinancialRecord[]
+    saleRequests: SaleRequest[]
 }
 
 const dataFilePath = path.join(process.cwd(), "src/data/workshopData.json")
@@ -94,6 +114,7 @@ async function ensureDataFile(): Promise<void> {
             serviceOrders: [],
             maintenanceTasks: [],
             financialRecords: [],
+            saleRequests: [],
         }
         await fs.mkdir(path.dirname(dataFilePath), { recursive: true })
         await fs.writeFile(dataFilePath, JSON.stringify(defaultData, null, 2), "utf-8")
@@ -111,6 +132,7 @@ export async function readWorkshopData(): Promise<WorkshopData> {
         serviceOrders: parsed.serviceOrders ?? [],
         maintenanceTasks: parsed.maintenanceTasks ?? [],
         financialRecords: parsed.financialRecords ?? [],
+        saleRequests: parsed.saleRequests ?? [],
     }
 }
 


### PR DESCRIPTION
## Summary
- add workshop data helpers so the Python workflow engine reads and writes the shared vendas JSON
- implement vendas node execution to list available inventory and record purchase or solicitation requests
- process user replies in the Python bot to register sale requests and move through the workflow

## Testing
- python -m compileall src/aura/chatbot

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692afe137d8483268fc5615a07d87209)