### PR TITLE
Normalize venda node type in workflow builder

### DIFF
--- a/app/panel/vendas/actions.ts
+++ b/app/panel/vendas/actions.ts
@@ -270,7 +270,7 @@ export async function createServiceOrder(formData: FormData) {
 
     const updatedServiceOrders = [newOrder, ...data.serviceOrders]
 
-    const updatedFinancialRecords =
+    const updatedFinancialRecords: FinancialRecord[] =
         normalizedAmountPaid > 0
             ? [
                   ...data.financialRecords,

--- a/src/aura/bot_components_api.py
+++ b/src/aura/bot_components_api.py
@@ -31,6 +31,21 @@ logger = logging.getLogger(__name__)
 # Timezone Brasil
 BRASIL_TZ = timezone(timedelta(hours=-3))
 
+
+def _normalize_node_type(node_type: Optional[str]) -> str:
+    """Canonicaliza tipos de nós vindos do editor."""
+
+    if not node_type:
+        return ""
+
+    normalized = node_type.lower()
+
+    # O editor já envia "venda", mas versões antigas salvavam "vendas".
+    if normalized == "vendas":
+        return "venda"
+
+    return normalized
+
 @dataclass
 class NodeData:
     """Dados de um nó do fluxo"""
@@ -112,6 +127,9 @@ def parse_workflow_data(workflow_data: Dict) -> Tuple[List[FlowNode], List[FlowE
         # Parsear nós REAIS
         nodes = []
         for node_raw in nodes_raw:
+            raw_type = node_raw.get("type", "")
+            normalized_type = _normalize_node_type(raw_type)
+
             node_data = NodeData(
                 label=node_raw.get("data", {}).get("label", ""),
                 description=node_raw.get("data", {}).get("description", ""),
@@ -134,11 +152,19 @@ def parse_workflow_data(workflow_data: Dict) -> Tuple[List[FlowNode], List[FlowE
 
             node = FlowNode(
                 id=node_raw.get("id", ""),
-                type=node_raw.get("type", ""),
+                type=normalized_type,
                 data=node_data,
                 position=node_raw.get("position", {})
             )
             nodes.append(node)
+
+            if raw_type != normalized_type:
+                logger.info(
+                    "Normalizando tipo do nó %s: '%s' -> '%s'",
+                    node.id,
+                    raw_type,
+                    normalized_type,
+                )
 
         # Parsear edges REAIS
         edges = []
@@ -957,11 +983,15 @@ def process_user_message(user_id: str, workflow_id: str, message: str) -> Dict[s
                 elif current_node.type == "venda":
                     intro = current_node.data.message or "Confira os itens disponíveis para venda:"
 
+                    logger.info("[VENDA] Iniciando nó de vendas %s", current_node.id)
+
                     try:
                         available_items = _fetch_available_inventory()
                     except Exception:
                         logger.exception("Falha ao carregar inventário para o nó de vendas")
                         available_items = []
+
+                    logger.info("[VENDA] Inventário carregado com %s itens", len(available_items))
 
                     logger.info(
                         "Nó de vendas carregado (%s): %s itens elegíveis",
@@ -1218,6 +1248,13 @@ def process_user_message(user_id: str, workflow_id: str, message: str) -> Dict[s
                 sale_items = sale_state.get("items", [])
                 user_input = message.strip()
 
+                logger.info(
+                    "[VENDA] Mensagem recebida na etapa '%s' do nó %s: %s",
+                    stage,
+                    current_node.id,
+                    user_input,
+                )
+
                 if stage == "selection":
                     if not user_input.isdigit():
                         return {
@@ -1233,12 +1270,16 @@ def process_user_message(user_id: str, workflow_id: str, message: str) -> Dict[s
 
                     option = int(user_input)
 
+                    logger.info("[VENDA] Opção selecionada: %s", option)
+
                     if option == 0:
                         execution.sale_state = {
                             "stage": "customName",
                             "items": sale_items,
                             "selected": None,
                         }
+
+                        logger.info("[VENDA] Cliente solicitou item fora da lista")
 
                         return {
                             "success": True,
@@ -1253,6 +1294,8 @@ def process_user_message(user_id: str, workflow_id: str, message: str) -> Dict[s
 
                     if 1 <= option <= len(sale_items):
                         selected = sale_items[option - 1]
+
+                        logger.info("[VENDA] Item escolhido: %s", selected.get("name"))
 
                         try:
                             stock = int(selected.get("stockQuantity", 0))
@@ -1276,6 +1319,8 @@ def process_user_message(user_id: str, workflow_id: str, message: str) -> Dict[s
                             "items": sale_items,
                             "selected": selected,
                         }
+
+                        logger.info("[VENDA] Avançando para coleta de telefone")
 
                         summary = f"Você escolheu {selected.get('name', 'item')} - {_format_currency(selected.get('unitPrice'))}."
                         prompt = (
@@ -1342,6 +1387,8 @@ def process_user_message(user_id: str, workflow_id: str, message: str) -> Dict[s
                             f"Solicitação registrada para {user_input}. Entraremos em contato até {_format_date_iso(contact_by)} "
                             "sobre o item."
                         )
+
+                    logger.info("[VENDA] Solicitação registrada para item customizado: %s", user_input)
 
                     messages_to_send.append({"text": message, "options": []})
 
@@ -1552,6 +1599,12 @@ def process_user_message(user_id: str, workflow_id: str, message: str) -> Dict[s
                 if stage == "phone":
                     selected = sale_state.get("selected", {})
                     contact = user_input
+
+                    logger.info(
+                        "[VENDA] Registrando reserva para '%s' com contato '%s'",
+                        selected.get("name"),
+                        contact,
+                    )
 
                     try:
                         request = _register_sale_request(

--- a/src/aura/features/view/flow/workflow-builder.tsx
+++ b/src/aura/features/view/flow/workflow-builder.tsx
@@ -90,7 +90,7 @@ const edgeTypes: EdgeTypes = {
 let removeNodeById: (id: string) => void = () => {}
 let updateNodeDataById: (id: string, data: any) => void = () => {}
 
-const normalizeNodeType = (type: string) => {
+const normalizeNodeType = (type?: string) => {
     if (!type) return type
 
     const normalized = type.toLowerCase()

--- a/src/aura/features/view/flow/workflow-builder.tsx
+++ b/src/aura/features/view/flow/workflow-builder.tsx
@@ -90,6 +90,22 @@ const edgeTypes: EdgeTypes = {
 let removeNodeById: (id: string) => void = () => {}
 let updateNodeDataById: (id: string, data: any) => void = () => {}
 
+const normalizeNodeType = (type: string) => {
+    if (!type) return type
+
+    const normalized = type.toLowerCase()
+
+    if (normalized === "vendas") return "venda"
+
+    return normalized
+}
+
+const normalizeWorkflowNodes = (nodes: Node<WorkflowNode["data"]>[]) =>
+    nodes.map((node) => ({
+        ...node,
+        type: normalizeNodeType(node.type),
+    }))
+
 // Fluxo padrão que sempre funciona - COMPLETAMENTE CONECTADO
 // Fluxo padrão que sempre funciona
 const createDefaultWorkflow = () => {
@@ -378,7 +394,7 @@ function WorkflowBuilderInner({
                 const savedWorkflow = localStorage.getItem(WORKFLOW_KEY)
                 if (savedWorkflow) {
                     const workflow = JSON.parse(savedWorkflow)
-                    setNodes(workflow.nodes || [])
+                    setNodes(normalizeWorkflowNodes(workflow.nodes || []))
                     setEdges(workflow.edges || [])
                     setNodeCounters(workflow.nodeCounters || {})
 
@@ -573,8 +589,9 @@ function WorkflowBuilderInner({
 
             const reactFlowBounds = reactFlowWrapper.current?.getBoundingClientRect()
             const type = event.dataTransfer.getData("application/reactflow")
+            const normalizedType = normalizeNodeType(type)
 
-            if (typeof type === "undefined" || !type || type === "start") {
+            if (typeof normalizedType === "undefined" || !normalizedType || normalizedType === "start") {
                 return
             }
 
@@ -585,12 +602,12 @@ function WorkflowBuilderInner({
                 })
 
                 const newNode = createNode({
-                    type,
+                    type: normalizedType,
                     position,
-                    id: generateNodeId(type),
+                    id: generateNodeId(normalizedType),
                 })
 
-                const simpleId = generateSimpleId(type)
+                const simpleId = generateSimpleId(normalizedType)
                 newNode.data = {
                     ...newNode.data,
                     customId: simpleId,
@@ -980,11 +997,13 @@ function WorkflowBuilderInner({
                         loadedNodes.unshift(startNode)
                     }
 
-                    setNodes(loadedNodes)
+                    const normalizedNodes = normalizeWorkflowNodes(loadedNodes)
+
+                    setNodes(normalizedNodes)
                     setEdges(loadedEdges)
                     setNodeCounters(loadedCounters || {})
 
-                    const workflow = { nodes: loadedNodes, edges: loadedEdges, nodeCounters: loadedCounters || {} }
+                    const workflow = { nodes: normalizedNodes, edges: loadedEdges, nodeCounters: loadedCounters || {} }
                     localStorage.setItem(WORKFLOW_KEY, JSON.stringify(workflow))
 
                     localStorage.removeItem(EXECUTED_KEY)


### PR DESCRIPTION
## Summary
- normalize workflow node types (including venda/vendas casing) when loading, importing, and creating nodes
- ensure newly dropped nodes use normalized identifiers and counters to align with backend expectations

## Testing
- Not run (next lint prompts for interactive setup)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b6aed23488326bfaf4b006766ace1)